### PR TITLE
Fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AUTH=enable
 ARG DASHBOARD=enable
 ARG GRAPHIQL=enable
 
-RUN apk add build-base curl imagemagick inotify-tools 
+RUN apk add git build-base curl imagemagick inotify-tools 
 
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
Add missing `git` package to Dockerfile. This is needed since we have some dependencies that are pulled from GitHub rather than from Hex