### PR TITLE
GraphQL API for available lists and available list entries

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -1,0 +1,7 @@
+{
+    "skip_files": [
+        "test",
+        "lib/ferry_web/router.ex",
+        "lib/ferry_web/endpoint.ex"
+    ]
+}

--- a/lib/ferry/aid/aid.ex
+++ b/lib/ferry/aid/aid.ex
@@ -22,6 +22,7 @@ defmodule Ferry.Aid do
   alias Ferry.Aid.Entry
   alias Ferry.AidTaxonomy.Item
   alias Ferry.Profiles.Project
+  alias Ferry.Locations.Address
 
   @doc """
   Return the aid list for the given id
@@ -245,7 +246,7 @@ defmodule Ferry.Aid do
   @doc """
   Returns all available lists for a given address
   """
-  @spec get_available_list(Address.t()) :: [AvailableList.t()]
+  @spec get_available_lists(Address.t()) :: [AvailableList.t()]
   def get_available_lists(address) do
     address_id = address.id
 
@@ -353,7 +354,7 @@ defmodule Ferry.Aid do
   list. A list can be either a needs list, an availability list
   or a manifest list
   """
-  @spec create_entry(AidList.t(), Item.t(), map()) ::
+  @spec create_entry(AidList.t() | NeedsList.t() | AvailableList.t(), Item.t(), map()) ::
           {:ok, Entry.t()} | {:error, Ecto.Changeset.t()}
   def create_entry(%AidList{} = list, %Item{} = item, attrs) do
     attrs =

--- a/lib/ferry/aid/aid.ex
+++ b/lib/ferry/aid/aid.ex
@@ -18,6 +18,7 @@ defmodule Ferry.Aid do
 
   alias Ferry.Aid.AidList
   alias Ferry.Aid.NeedsList
+  alias Ferry.Aid.AvailableList
   alias Ferry.Aid.Entry
   alias Ferry.AidTaxonomy.Item
   alias Ferry.Profiles.Project
@@ -219,6 +220,81 @@ defmodule Ferry.Aid do
   end
 
   @doc """
+  Returns an available list given its id
+  """
+  @spec get_available_list(integer()) :: {:ok, AvailableList.t()} | :not_found
+  def get_available_list(id) do
+    case AvailableList
+         |> Repo.get(id)
+         |> Repo.preload(at: [:project, :group])
+         |> Repo.preload(
+           entries: [
+             item: [:mods, :category],
+             list: [:needs_list, :available_list, :manifest_list]
+           ]
+         )
+         |> Repo.preload(:list) do
+      nil ->
+        :not_found
+
+      available_list ->
+        {:ok, available_list}
+    end
+  end
+
+  @doc """
+  Returns all available lists for a given address
+  """
+  @spec get_available_list(Address.t()) :: [AvailableList.t()]
+  def get_available_lists(address) do
+    address_id = address.id
+
+    from(available_list in AvailableList,
+      where: available_list.address_id == ^address_id
+    )
+    |> Repo.all()
+    |> Repo.preload(at: [:project, :group])
+    |> Repo.preload(
+      entries: [
+        item: [:mods, :category],
+        list: [:needs_list, :available_list, :manifest_list]
+      ]
+    )
+    |> Repo.preload(:list)
+  end
+
+  @doc """
+  Creates a new available list for the given address
+  """
+  @spec create_available_list(Address.t(), map()) ::
+          {:ok, AvailableList.t()} | {:error, Ecto.Changeset.t()}
+  def create_available_list(address, attrs \\ %{}) do
+    attrs =
+      attrs
+      |> Map.put(:address_id, address.id)
+
+    with {:ok, available_list} <-
+           %AvailableList{}
+           |> AvailableList.create_changeset(attrs)
+           |> Changeset.put_assoc(:list, %AidList{entries: []})
+           |> Repo.insert() do
+      get_available_list(available_list.id)
+    end
+  end
+
+  @doc """
+  Deletes an available list.
+
+  If the list has entries, they will also be deleted
+  """
+  @spec delete_available_list(AvailableList.t()) ::
+          {:ok, AvailableList.t()} | {:error, Ecto.Changeset.t()}
+  def delete_available_list(%AvailableList{} = list) do
+    list
+    |> Repo.delete()
+  end
+
+  @doc """
   Counts all entries in the database
   """
   @spec count_entries() :: integer()
@@ -231,9 +307,15 @@ defmodule Ferry.Aid do
   Returns all entries for a list. A list can be either
   a needs list, available list or a manifest list
   """
-  @spec get_entries(NeedsList.t()) :: [Entry.t()]
+  @spec get_entries(NeedsList.t() | AvailableList.t()) :: [Entry.t()]
   def get_entries(%NeedsList{} = needs) do
     with {:ok, list} <- aid_list_for(needs) do
+      get_entries(list)
+    end
+  end
+
+  def get_entries(%AvailableList{} = available) do
+    with {:ok, list} <- aid_list_for(available) do
       get_entries(list)
     end
   end
@@ -293,6 +375,12 @@ defmodule Ferry.Aid do
     end
   end
 
+  def create_entry(%AvailableList{} = list, %Item{} = item, attrs) do
+    with {:ok, list} <- aid_list_for(list) do
+      create_entry(list, item, attrs)
+    end
+  end
+
   @doc """
   Updates a list entry.
 
@@ -311,7 +399,16 @@ defmodule Ferry.Aid do
   defp aid_list_for(%NeedsList{id: id}) do
     case Repo.get_by(AidList, needs_list_id: id) do
       nil ->
-        IO.inspect(Repo.all(AidList))
+        :not_found
+
+      list ->
+        {:ok, list}
+    end
+  end
+
+  defp aid_list_for(%AvailableList{id: id}) do
+    case Repo.get_by(AidList, available_list_id: id) do
+      nil ->
         :not_found
 
       list ->

--- a/lib/ferry/aid/available_list.ex
+++ b/lib/ferry/aid/available_list.ex
@@ -4,6 +4,8 @@ defmodule Ferry.Aid.AvailableList do
 
   alias Ferry.Aid.AidList
 
+  @type t() :: %__MODULE__{}
+
   schema "aid__available_lists" do
     belongs_to :at, Ferry.Locations.Address, foreign_key: :address_id
 

--- a/lib/ferry/aid/entry.ex
+++ b/lib/ferry/aid/entry.ex
@@ -5,6 +5,8 @@ defmodule Ferry.Aid.Entry do
   alias Ferry.Aid.AidList
   alias Ferry.AidTaxonomy.Item
 
+  @type t() :: %__MODULE__{}
+
   schema "aid__list_entries" do
     field :amount, :integer, default: 0
 

--- a/lib/ferry_api/available_list_entry_type.ex
+++ b/lib/ferry_api/available_list_entry_type.ex
@@ -1,0 +1,15 @@
+defmodule FerryApi.Schema.AvailableListEntryType do
+  use Absinthe.Schema.Notation
+
+  import AbsintheErrorPayload.Payload
+
+  object :available_list_entry do
+    field :id, non_null(:id)
+    field :amount, :integer
+
+    field :list, non_null(:available_list)
+    field :item, non_null(:item)
+  end
+
+  payload_object(:available_list_entry_payload, :available_list_entry)
+end

--- a/lib/ferry_api/available_list_schema.ex
+++ b/lib/ferry_api/available_list_schema.ex
@@ -1,0 +1,114 @@
+defmodule FerryApi.Schema.AvailableList do
+  use Absinthe.Schema.Notation
+
+  import AbsintheErrorPayload.Payload
+  alias FerryApi.Middleware
+  alias Ferry.Aid
+  alias Ferry.Locations
+
+  object :available_list_queries do
+    @desc "Returns a single available list"
+    field :available_list, :available_list do
+      arg(:id, non_null(:id))
+      resolve(&available_list/3)
+    end
+
+    @desc "Returns all available lists at a given address"
+    field :available_lists, list_of(:available_list) do
+      arg(:at, non_null(:id))
+      resolve(&available_lists/3)
+    end
+  end
+
+  input_object :available_list_input do
+    field :at, non_null(:id)
+  end
+
+  object :available_list_mutations do
+    @desc "Create an available list"
+    field :create_available_list, type: :available_list_payload do
+      arg(:available_list_input, non_null(:available_list_input))
+      middleware(Middleware.RequireUser)
+      resolve(&create_available_list/3)
+      middleware(&build_payload/2)
+    end
+
+    @desc "Delete an available list"
+    field :delete_available_list, type: :available_list_payload do
+      arg(:id, non_null(:id))
+      middleware(Middleware.RequireUser)
+      resolve(&delete_available_list/3)
+      middleware(&build_payload/2)
+    end
+  end
+
+  @address_not_found "address not found"
+  @available_list_not_found "available list not found"
+
+  @doc """
+  Returns an availabe list given its id
+
+  """
+  @spec available_list(any(), %{id: integer()}, any()) ::
+          {:ok, map()} | {:error, term()}
+  def available_list(_, %{id: id}, _) do
+    with :not_found <- Aid.get_available_list(id) do
+      {:error, @available_list_not_found}
+    end
+  end
+
+  @doc """
+  Returns all available lists at a given address
+
+  """
+  @spec available_lists(any(), %{at: String.t()}, any()) ::
+          {:ok, [map()]} | {:error, term()}
+  def available_lists(_, %{at: address}, _) do
+    case Locations.get_address(address) do
+      nil ->
+        {:error, @address_not_found}
+
+      address ->
+        {:ok, Aid.get_available_lists(address)}
+    end
+  end
+
+  @doc """
+  Graphql resolver that creates a available list.
+
+  """
+  @spec create_available_list(
+          any,
+          %{available_list_input: map()},
+          any
+        ) :: {:error, Ecto.Changeset.t()} | {:ok, map()}
+  def create_available_list(
+        _parent,
+        %{available_list_input: %{at: address} = attrs},
+        _resolution
+      ) do
+    case Locations.get_address(address) do
+      nil ->
+        {:error, @address_not_found}
+
+      address ->
+        Aid.create_available_list(address, Map.drop(attrs, [:at]))
+    end
+  end
+
+  @doc """
+  Deletes an available list
+
+  """
+  @spec delete_available_list(any(), %{id: integer()}, any()) ::
+          {:ok, map()} | {:error, term()}
+  def delete_available_list(_, %{id: id}, _) do
+    case Aid.get_available_list(id) do
+      :not_found ->
+        {:error, @available_list_not_found}
+
+      {:ok, available_list} ->
+        Aid.delete_available_list(available_list)
+    end
+  end
+end

--- a/lib/ferry_api/available_list_type.ex
+++ b/lib/ferry_api/available_list_type.ex
@@ -1,0 +1,13 @@
+defmodule FerryApi.Schema.AvailableListType do
+  use Absinthe.Schema.Notation
+
+  import AbsintheErrorPayload.Payload
+
+  object :available_list do
+    field :id, non_null(:id)
+    field :at, non_null(:address)
+    field :entries, list_of(:available_list_entry)
+  end
+
+  payload_object(:available_list_payload, :available_list)
+end

--- a/lib/ferry_api/needs_list_schema.ex
+++ b/lib/ferry_api/needs_list_schema.ex
@@ -173,7 +173,7 @@ defmodule FerryApi.Schema.NeedsList do
 
   """
   @spec delete_needs_list(any(), %{id: String.t()}, any()) ::
-          {:ok, [map()]} | {:error, term()}
+          {:ok, map()} | {:error, term()}
   def delete_needs_list(_, %{id: id}, _) do
     case Aid.get_needs_list(id) do
       :not_found ->

--- a/lib/ferry_api/schema.ex
+++ b/lib/ferry_api/schema.ex
@@ -48,6 +48,12 @@ defmodule FerryApi.Schema do
   import_types(FerryApi.Schema.NeedsListEntryType)
   import_types(FerryApi.Schema.NeedsListEntry)
 
+  import_types(FerryApi.Schema.AvailableListType)
+  import_types(FerryApi.Schema.AvailableList)
+
+  import_types(FerryApi.Schema.AvailableListEntryType)
+  import_types(FerryApi.Schema.AvailableListEntry)
+
   # Queries
   # ------------------------------------------------------------
 
@@ -65,6 +71,8 @@ defmodule FerryApi.Schema do
     import_fields(:package_queries)
     import_fields(:needs_list_queries)
     import_fields(:needs_list_entry_queries)
+    import_fields(:available_list_queries)
+    import_fields(:available_list_entry_queries)
   end
 
   # Mutuations
@@ -82,6 +90,8 @@ defmodule FerryApi.Schema do
     import_fields(:package_mutations)
     import_fields(:needs_list_mutations)
     import_fields(:needs_list_entry_mutations)
+    import_fields(:available_list_mutations)
+    import_fields(:available_list_entry_mutations)
   end
 
   @sources [

--- a/test/ferry_api/available_list_api_test.exs
+++ b/test/ferry_api/available_list_api_test.exs
@@ -1,0 +1,63 @@
+defmodule Ferry.AvailableListApiTest do
+  use FerryWeb.ConnCase, async: true
+  import Ferry.ApiClient.AvailableList
+
+  setup context do
+    insert(:user)
+    |> mock_sign_in
+
+    Ferry.Fixture.AvailableListWithEntry.setup(context)
+  end
+
+  describe "available list graphql api" do
+    test "returns all available lists for an address", %{
+      conn: conn,
+      address: address,
+      available: id
+    } do
+      %{
+        "data" => %{
+          "availableLists" => [
+            %{"id" => ^id}
+          ]
+        }
+      } =
+        get_available_lists(conn, %{
+          address: address
+        })
+    end
+
+    test "fetches a single available list", %{conn: conn, available: id} do
+      %{
+        "data" => %{
+          "availableList" => %{"id" => ^id}
+        }
+      } = get_available_list(conn, id)
+    end
+
+    test "deletes an available list", %{conn: conn, address: address, available: id} do
+      %{
+        "data" => %{
+          "deleteAvailableList" => %{
+            "successful" => true
+          }
+        }
+      } = delete_available_list(conn, id)
+
+      %{
+        "data" => %{
+          "availableLists" => []
+        }
+      } =
+        get_available_lists(conn, %{
+          address: address
+        })
+
+      %{
+        "data" => %{
+          "availableList" => nil
+        }
+      } = get_available_list(conn, id)
+    end
+  end
+end

--- a/test/ferry_api/available_list_entry_api_test.exs
+++ b/test/ferry_api/available_list_entry_api_test.exs
@@ -1,61 +1,61 @@
-defmodule Ferry.NeedsListEntryApiTest do
+defmodule Ferry.AvailableListEntryApiTest do
   use FerryWeb.ConnCase, async: true
-  import Ferry.ApiClient.{NeedsList, NeedsListEntry}
+  import Ferry.ApiClient.{AvailableList, AvailableListEntry}
 
   setup context do
     insert(:user)
     |> mock_sign_in
 
-    Ferry.Fixture.NeedsWithEntry.setup(context)
+    Ferry.Fixture.AvailableListWithEntry.setup(context)
   end
 
-  describe "needs list entry graphql api" do
-    test "needs list also returns its entries", %{conn: conn, needs: needs, entry: entry} do
+  describe "available list entry graphql api" do
+    test "available list also returns its entries", %{conn: conn, available: id, entry: entry} do
       %{
         "data" => %{
-          "needsList" => %{
-            "id" => ^needs,
+          "availableList" => %{
+            "id" => ^id,
             "entries" => [%{"id" => ^entry}]
           }
         }
-      } = get_needs_list(conn, needs)
+      } = get_available_list(conn, id)
     end
 
-    test "creates need list entries", %{conn: conn, needs: needs, item: item} do
+    test "creates available list entries", %{conn: conn, available: id, item: item} do
       %{
         "data" => %{
-          "createNeedsListEntry" => %{
+          "createAvailableListEntry" => %{
             "successful" => true,
             "messages" => [],
             "result" => %{
               "id" => _,
               "amount" => 1,
               "item" => %{"id" => ^item},
-              "list" => %{"id" => ^needs}
+              "list" => %{"id" => ^id}
             }
           }
         }
       } =
-        create_needs_list_entry(conn, %{
-          list: needs,
+        create_available_list_entry(conn, %{
+          list: id,
           item: item,
           amount: 1
         })
 
       %{
         "data" => %{
-          "needsList" => %{
-            "id" => ^needs,
+          "availableList" => %{
+            "id" => ^id,
             "entries" => [_, _]
           }
         }
-      } = get_needs_list(conn, needs)
+      } = get_available_list(conn, id)
     end
 
-    test "deletes needs list entries", %{conn: conn, needs: needs, entry: entry} do
+    test "deletes available list entries", %{conn: conn, available: id, entry: entry} do
       %{
         "data" => %{
-          "deleteNeedsListEntry" => %{
+          "deleteAvailableListEntry" => %{
             "successful" => true,
             "messages" => [],
             "result" => %{
@@ -63,27 +63,27 @@ defmodule Ferry.NeedsListEntryApiTest do
             }
           }
         }
-      } = delete_needs_list_entry(conn, entry)
+      } = delete_available_list_entry(conn, entry)
 
       %{
         "data" => %{
-          "needsList" => %{
-            "id" => ^needs,
+          "availableList" => %{
+            "id" => ^id,
             "entries" => []
           }
         }
-      } = get_needs_list(conn, needs)
+      } = get_available_list(conn, id)
     end
 
-    test "updates an needs list entry amount", %{
+    test "updates an available list entry amount", %{
       conn: conn,
-      needs: needs,
+      available: id,
       item: item,
       entry: entry
     } do
       %{
         "data" => %{
-          "updateNeedsListEntry" => %{
+          "updateAvailableListEntry" => %{
             "successful" => true,
             "messages" => [],
             "result" => %{
@@ -92,33 +92,33 @@ defmodule Ferry.NeedsListEntryApiTest do
           }
         }
       } =
-        update_needs_list_entry(conn, %{
+        update_available_list_entry(conn, %{
           id: entry,
-          list: needs,
+          list: id,
           item: item,
           amount: 2
         })
 
       %{
         "data" => %{
-          "needsList" => %{
-            "id" => ^needs,
+          "availableList" => %{
+            "id" => ^id,
             "entries" => [%{"amount" => 2}]
           }
         }
-      } = get_needs_list(conn, needs)
+      } = get_available_list(conn, id)
 
       %{
         "data" => %{
-          "needsListEntry" => %{
+          "availableListEntry" => %{
             "id" => ^entry,
             "list" => %{
-              "id" => ^needs
+              "id" => ^id
             },
             "amount" => 2
           }
         }
-      } = get_needs_list_entry(conn, entry)
+      } = get_available_list_entry(conn, entry)
     end
   end
 end

--- a/test/ferry_api/needs_list_entry_api_test.exs
+++ b/test/ferry_api/needs_list_entry_api_test.exs
@@ -1,6 +1,6 @@
 defmodule Ferry.EntryApiTest do
   use FerryWeb.ConnCase, async: true
-  import Ferry.ApiClient.{NeedsList, Entry}
+  import Ferry.ApiClient.{NeedsList, NeedsListEntry}
 
   setup context do
     insert(:user)

--- a/test/support/api_client/available_list.ex
+++ b/test/support/api_client/available_list.ex
@@ -1,0 +1,108 @@
+defmodule Ferry.ApiClient.AvailableList do
+  @moduledoc """
+  Helper module that provides with a convenience GraphQL client api
+  for dealing with Available Lists in tests.
+  """
+
+  import Ferry.ApiClient.GraphCase
+
+  @doc """
+  Run a GraphQL mutation that creates an available list
+  """
+  @spec create_available_list(Plug.Conn.t(), map()) :: map()
+  def create_available_list(conn, attrs) do
+    graphql(conn, """
+      mutation {
+        createAvailableList(
+          availableListInput: {
+            address: "#{attrs.project}",
+          }
+        ) {
+          successful,
+          messages {
+            field
+            message
+          },
+          result {
+            id,
+            address {
+              id,
+              group {
+                id,
+                name
+              }
+            }
+            entries {
+              id,
+              item {
+                id
+              },
+              amount
+            }
+          }
+        }
+      }
+    """)
+  end
+
+  @doc """
+  Run a GraphQL mutation that creates an available list
+  """
+  @spec update_available_list(Plug.Conn.t(), map()) :: map()
+  def update_available_list(conn, attrs) do
+    graphql(conn, """
+      mutation {
+        updateAvailableList(
+            id: "#{attrs.id}",
+            availableListInput: {
+              address: "#{attrs.address}"
+            }
+          ) {
+            successful,
+            messages {
+              field
+              message
+            },
+            result {
+              id,
+              address {
+                id,
+                group {
+                  id,
+                  name
+                }
+              }
+              entries {
+                id,
+                item {
+                  id
+                },
+                amount
+              }
+            }
+          }
+        }
+    """)
+  end
+
+  @doc """
+  Run a GraphQL mutation that deletes an available list, given its id
+  """
+  @spec delete_available_list(Plug.Conn.t(), String.t()) :: map()
+  def delete_available_list(conn, id) do
+    graphql(conn, """
+      mutation {
+        deleteAvailableList(id: "#{id}") {
+          successful,
+          messages {
+            field
+            message
+          },
+          result {
+            id
+          }
+        }
+      }
+    """)
+  end
+end

--- a/test/support/api_client/available_list.ex
+++ b/test/support/api_client/available_list.ex
@@ -7,6 +7,62 @@ defmodule Ferry.ApiClient.AvailableList do
   import Ferry.ApiClient.GraphCase
 
   @doc """
+  GraphQL query that returns all available lists for a given address
+  """
+  @spec get_available_lists(Plug.Conn.t(), map()) :: map()
+  def get_available_lists(conn, attrs) do
+    graphql(conn, """
+    {
+      availableLists(at: "#{attrs.address}") {
+        id,
+        at {
+          id,
+          group {
+            id,
+            name
+          }
+        }
+        entries {
+          id,
+          item {
+            id
+          },
+          amount
+        }
+      }
+    }
+    """)
+  end
+
+  @doc """
+  GraphQL query that returns an available list given its id
+  """
+  @spec get_available_list(Plug.Conn.t(), String.t()) :: map()
+  def get_available_list(conn, id) do
+    graphql(conn, """
+    {
+      availableList(id: "#{id}") {
+        id,
+        at {
+          id,
+          group {
+            id,
+            name
+          }
+        }
+        entries {
+          id,
+          item {
+            id
+          },
+          amount
+        }
+      }
+    }
+    """)
+  end
+
+  @doc """
   Run a GraphQL mutation that creates an available list
   """
   @spec create_available_list(Plug.Conn.t(), map()) :: map()
@@ -15,7 +71,7 @@ defmodule Ferry.ApiClient.AvailableList do
       mutation {
         createAvailableList(
           availableListInput: {
-            address: "#{attrs.project}",
+            at: "#{attrs.address}",
           }
         ) {
           successful,
@@ -25,7 +81,7 @@ defmodule Ferry.ApiClient.AvailableList do
           },
           result {
             id,
-            address {
+            at {
               id,
               group {
                 id,
@@ -55,7 +111,7 @@ defmodule Ferry.ApiClient.AvailableList do
         updateAvailableList(
             id: "#{attrs.id}",
             availableListInput: {
-              address: "#{attrs.address}"
+              at: "#{attrs.address}"
             }
           ) {
             successful,
@@ -65,7 +121,7 @@ defmodule Ferry.ApiClient.AvailableList do
             },
             result {
               id,
-              address {
+              at {
                 id,
                 group {
                   id,

--- a/test/support/api_client/available_list_entry.ex
+++ b/test/support/api_client/available_list_entry.ex
@@ -1,0 +1,133 @@
+defmodule Ferry.ApiClient.AvailableListEntry do
+  @moduledoc """
+  Helper module that provides with a convenience GraphQL client api
+  for dealing with Entries in tests.
+  """
+
+  import Ferry.ApiClient.GraphCase
+
+  @doc """
+  Run a GraphQL query that retuns an entry given its
+  id
+  """
+  @spec get_available_list_entry(Plug.Conn.t(), String.t()) :: map()
+  def get_available_list_entry(conn, id) do
+    graphql(conn, """
+    {
+      availableListEntry(id: "#{id}") {
+        id,
+        list {
+          id
+        },
+        amount,
+        item {
+          id,
+          name
+          category {
+            id,
+            name
+          }
+        }
+      }
+    }
+    """)
+  end
+
+  @doc """
+  Run a GraphQL mutation that creates a entry
+  under a given aid list
+  """
+  @spec create_available_list_entry(Plug.Conn.t(), map()) :: map()
+  def create_available_list_entry(conn, attrs) do
+    graphql(conn, """
+      mutation {
+        createAvailableListEntry (
+          entryInput: {
+            list: "#{attrs.list}",
+            amount: #{attrs[:amount] || 1},
+            item: "#{attrs.item}"
+          }
+        ) {
+          successful,
+          messages { field, message },
+          result {
+            id,
+            list {
+              id
+            },
+            amount,
+            item {
+              id,
+              name
+              category {
+                id,
+                name
+              }
+            }
+          }
+        }
+      }
+    """)
+  end
+
+  @doc """
+  Run a GraphQL mutation that updates a list entry.
+
+  We are using an entryInput type for consistency, however,
+  in reality only the amount can be changed at the moment.
+  """
+  @spec update_available_list_entry(Plug.Conn.t(), map()) :: map()
+  def update_available_list_entry(conn, attrs) do
+    graphql(conn, """
+      mutation {
+        updateAvailableListEntry(
+          id: "#{attrs.id}",
+          entryInput: {
+            list: "#{attrs.list}",
+            amount: #{attrs[:amount] || 1},
+            item: "#{attrs.item}"
+          }
+        ){
+          successful,
+          messages { field, message },
+          result {
+            id,
+            list {
+              id,
+            },
+            amount,
+            item {
+              id,
+              name
+              category {
+                id,
+                name
+              }
+            }
+          }
+        }
+      }
+    """)
+  end
+
+  @doc """
+  Run a GraphQL mutation that deletes a available list entry, given its id
+  """
+  @spec delete_available_list_entry(Plug.Conn.t(), String.t()) :: map()
+  def delete_available_list_entry(conn, id) do
+    graphql(conn, """
+      mutation {
+        deleteAvailableListEntry(id: "#{id}") {
+          successful,
+          messages {
+            field
+            message
+          },
+          result {
+            id
+          }
+        }
+      }
+    """)
+  end
+end

--- a/test/support/api_client/needs_list_entry.ex
+++ b/test/support/api_client/needs_list_entry.ex
@@ -1,4 +1,4 @@
-defmodule Ferry.ApiClient.Entry do
+defmodule Ferry.ApiClient.NeedsListEntry do
   @moduledoc """
   Helper module that provides with a convenience GraphQL client api
   for dealing with Entries in tests.

--- a/test/support/fixture/available_list_with_entry.ex
+++ b/test/support/fixture/available_list_with_entry.ex
@@ -1,0 +1,92 @@
+defmodule Ferry.Fixture.AvailableListWithEntry do
+  import Ferry.ApiClient.{Address, Group, AvailableList, Category, Item, AvailableListEntry}
+
+  def setup(%{conn: conn} = context) do
+    %{
+      "data" => %{
+        "createGroup" => %{
+          "successful" => true,
+          "result" => %{
+            "id" => group
+          }
+        }
+      }
+    } = create_simple_group(conn, %{name: "a group"})
+
+    %{
+      "data" => %{
+        "createAddress" => %{
+          "successful" => true,
+          "messages" => [],
+          "result" => %{
+            "id" => address
+          }
+        }
+      }
+    } = create_address(conn, %{group: group, label: "test"})
+
+    %{
+      "data" => %{
+        "createAvailableList" => %{
+          "successful" => true,
+          "result" => %{
+            "id" => available_list
+          }
+        }
+      }
+    } =
+      create_available_list(conn, %{
+        address: address
+      })
+
+    %{
+      "data" => %{
+        "createCategory" => %{
+          "successful" => true,
+          "result" => %{
+            "id" => category
+          }
+        }
+      }
+    } = create_category(conn, %{name: "clothes"})
+
+    %{
+      "data" => %{
+        "createItem" => %{
+          "successful" => true,
+          "result" => %{
+            "id" => item
+          }
+        }
+      }
+    } =
+      create_item(conn, %{
+        category: category,
+        name: "tshirt"
+      })
+
+    %{
+      "data" => %{
+        "createAvailableListEntry" => %{
+          "successful" => true,
+          "result" => %{
+            "id" => entry
+          }
+        }
+      }
+    } =
+      create_available_list_entry(conn, %{
+        list: available_list,
+        item: item,
+        amount: 1
+      })
+
+    {:ok,
+     Map.merge(context, %{
+       address: address,
+       available: available_list,
+       item: item,
+       entry: entry
+     })}
+  end
+end

--- a/test/support/fixture/needs_with_entry.ex
+++ b/test/support/fixture/needs_with_entry.ex
@@ -1,5 +1,5 @@
 defmodule Ferry.Fixture.NeedsWithEntry do
-  import Ferry.ApiClient.{Group, Project, NeedsList, Category, Item, Entry}
+  import Ferry.ApiClient.{Group, Project, NeedsList, Category, Item, NeedsListEntry}
 
   def setup(%{conn: conn} = context) do
     %{


### PR DESCRIPTION
This PR implements the GraphQL API for available lists and available list entries. It also provides with the supporting code in the Aid Phoenix Context and ExUnit tests.

Fixes #57 