### PR TITLE
List Entry vs ModValue GraphQL API

### DIFF
--- a/lib/ferry/aid/entry.ex
+++ b/lib/ferry/aid/entry.ex
@@ -3,6 +3,7 @@ defmodule Ferry.Aid.Entry do
   import Ecto.Changeset
 
   alias Ferry.Aid.AidList
+  alias Ferry.Aid.EntryModValue
   alias Ferry.AidTaxonomy.Item
 
   @type t() :: %__MODULE__{}
@@ -12,6 +13,8 @@ defmodule Ferry.Aid.Entry do
 
     belongs_to :list, AidList, foreign_key: :list_id
     belongs_to :item, Item
+
+    has_many :mod_values, EntryModValue, foreign_key: :entry_id
 
     timestamps()
   end

--- a/lib/ferry/aid/entry_mod_value.ex
+++ b/lib/ferry/aid/entry_mod_value.ex
@@ -1,0 +1,38 @@
+defmodule Ferry.Aid.EntryModValue do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Ferry.AidTaxonomy.ModValue
+  alias Ferry.Aid.Entry
+
+  @type t() :: %__MODULE__{}
+
+  schema "aid__list_entries__mod_values" do
+    belongs_to :entry, Entry, foreign_key: :entry_id
+    belongs_to :mod_value, ModValue, foreign_key: :mod_value_id
+    timestamps()
+  end
+
+  @required_fields ~w(entry_id mod_value_id)a
+
+  @doc """
+  Defines a changeset for a entry vs mod value relationship
+
+  Verifies integrity with both list entries and mod values tables, and also
+  ensures a mod value is added to the same entry only once. Returns constraints errors
+  as changeset errors so that they can be properly communicated back
+  to the client
+  """
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(entry_mod_value, params) do
+    entry_mod_value
+    |> cast(params, @required_fields)
+    |> validate_required(@required_fields)
+    |> foreign_key_constraint(:entry_id)
+    |> foreign_key_constraint(:mod_value_id)
+    |> unique_constraint([:entry, :mod_value],
+      name: "distinct_mod_values_per_list_entry",
+      message: "already exists"
+    )
+  end
+end

--- a/lib/ferry/aid/entry_mod_value.ex
+++ b/lib/ferry/aid/entry_mod_value.ex
@@ -4,6 +4,7 @@ defmodule Ferry.Aid.EntryModValue do
 
   alias Ferry.AidTaxonomy.ModValue
   alias Ferry.Aid.Entry
+  alias Ferry.Aid
 
   @type t() :: %__MODULE__{}
 
@@ -28,11 +29,120 @@ defmodule Ferry.Aid.EntryModValue do
     entry_mod_value
     |> cast(params, @required_fields)
     |> validate_required(@required_fields)
+    |> validate_mod_value_in_mods()
     |> foreign_key_constraint(:entry_id)
     |> foreign_key_constraint(:mod_value_id)
     |> unique_constraint([:entry, :mod_value],
       name: "distinct_mod_values_per_list_entry",
       message: "already exists"
     )
+  end
+
+  @doc """
+  Ensures the mod_value we are trying to add actually belongs to one of the
+  mods of the item to which the entry relates.
+
+  We also want to ensure we allow the right number of values:
+
+  * If the mod is of type `multi-select`, then more than one value is allowed.
+  * Otherwise, at most one value is allowed
+  """
+  @spec validate_mod_value_in_mods(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def validate_mod_value_in_mods(changeset) do
+    {:ok, entry} = Aid.get_entry(changeset.changes.entry_id, item_preload: :with_mod_values)
+
+    changeset
+    |> validate_with(entry, &mod_value_in_mods?/2, "must be within the entry's item mod values")
+    |> validate_with(entry, &mod_value_has_right_cardinality?/2, "has too many values")
+  end
+
+  # Generic function so that we can easily plug new validation
+  # rules in the future
+  defp validate_with(changeset, entry, fun, message) do
+    mod_value_id = changeset.changes.mod_value_id
+
+    case fun.(entry, mod_value_id) do
+      true ->
+        changeset
+
+      false ->
+        add_error(changeset, :mod_value, message)
+    end
+  end
+
+  # Checks whether the given mod_value id is known by the mods
+  # associated to the linked item
+  defp mod_value_in_mods?(%Entry{} = entry, mod_value_id) do
+    entry.item.mods
+    |> Enum.flat_map(fn %{values: values} -> values end)
+    |> Enum.reduce_while(false, fn
+      %{id: ^mod_value_id}, _ -> {:halt, true}
+      _, _ -> {:cont, false}
+    end)
+  end
+
+  # Checks whether it is legal to add a new mod value to
+  # the entry depending on the kind of mod (select vs multi-select)
+  # If the mod is of type select, and a mod value for the same
+  # mod already exists, then we should not allow
+  # a new value
+  #
+  # *Note*: this implementation is not free from potential
+  # race conditions. It would probably be safer to encode
+  # this constraint as a postgres function and let the database
+  # ensure data consistency
+  defp mod_value_has_right_cardinality?(entry, mod_value_id) do
+    case entry.mod_values do
+      [] ->
+        # for the moment, the entry has no mod values
+        # so we can add a new one no matter its type
+        true
+
+      _ ->
+        # There are some values already, so we need
+        # to inspect further
+        mod = mod_for(entry, mod_value_id)
+
+        case mod.type do
+          "multi-select" ->
+            # The mod is of type multi-select therefore
+            # it allows many values for the same mod
+            true
+
+          _ ->
+            # The mod is singe-valued, so we need to make
+            # sure we currently don't have values for that mod
+            mod_values_count = mod_values_count_by_mod(entry)
+            Map.get(mod_values_count, mod.id, 0) == 0
+        end
+    end
+  end
+
+  # Returns the parent mod for the given mod value id
+  defp mod_for(entry, mod_value_id) do
+    entry.item.mods
+    |> Enum.reduce(%{}, fn %{values: values} = mod, acc ->
+      Enum.reduce(values, acc, fn %{id: id}, acc2 ->
+        Map.put(acc2, id, mod)
+      end)
+    end)
+    |> Map.get(mod_value_id)
+    |> case do
+      nil ->
+        raise "Unable to find mod for mod value #{mod_value_id} in: #{inspect(entry.item.mods)}"
+
+      mod ->
+        mod
+    end
+  end
+
+  # Counts mod values by mod
+  defp mod_values_count_by_mod(entry) do
+    entry.mod_values
+    |> Enum.reduce(%{}, fn %{mod_value: %ModValue{mod: entry_mod_value_mod}}, acc ->
+      mod_id = entry_mod_value_mod.id
+      count = Map.get(acc, mod_id, 0)
+      Map.put(acc, mod_id, count + 1)
+    end)
   end
 end

--- a/lib/ferry_api/available_list_entry_mod_value_schema.ex
+++ b/lib/ferry_api/available_list_entry_mod_value_schema.ex
@@ -1,0 +1,101 @@
+defmodule FerryApi.Schema.AvailableListEntryModValue do
+  use Absinthe.Schema.Notation
+
+  import AbsintheErrorPayload.Payload
+  alias FerryApi.Middleware
+  alias Ferry.Aid
+  alias Ferry.AidTaxonomy
+
+  object :available_list_entry_mod_value_mutations do
+    @desc "Add an existing mod value to an existing available list entry"
+    field :add_mod_value_to_available_list_entry, type: :available_list_entry_payload do
+      arg(:entry_mod_value_input, non_null(:entry_mod_value_input))
+      middleware(Middleware.RequireUser)
+      resolve(&add_mod_value_to_list_entry/3)
+      middleware(&build_payload/2)
+    end
+
+    @desc "Remove an existing mod value from an existing available list entry"
+    field :remove_mod_value_from_available_list_entry, type: :available_list_entry_payload do
+      arg(:entry_mod_value_input, non_null(:entry_mod_value_input))
+      middleware(Middleware.RequireUser)
+      resolve(&remove_mod_value_from_list_entry/3)
+      middleware(&build_payload/2)
+    end
+  end
+
+  @entry_not_found "entry not found"
+  @mod_value_not_found "mod value not found"
+
+  @doc """
+  Graphql resolver that adds a new mod value to an existing
+  available list entry
+  """
+  @spec add_mod_value_to_list_entry(
+          any,
+          %{entry_mod_value_input: map()},
+          any
+        ) :: {:error, Ecto.Changeset.t()} | {:ok, map()}
+  def add_mod_value_to_list_entry(
+        _parent,
+        %{entry_mod_value_input: %{entry: entry, mod_value: mod_value}},
+        _resolution
+      ) do
+    case AidTaxonomy.get_mod_value(mod_value) do
+      nil ->
+        {:error, @mod_value_not_found}
+
+      mod_value ->
+        case Aid.get_entry(entry, item_preload: :with_mod_values) do
+          :not_found ->
+            {:error, @entry_not_found}
+
+          {:ok, entry} ->
+            with :ok <- Aid.add_mod_value_to_entry(mod_value, entry) do
+              # We need to return the entry as an available list entry
+              # and it has to be linked to its available list, for completeness
+              # with other apis. Since we have this convention
+              # already implemented in the available list schema module, we can
+              # simply reuse it.
+              FerryApi.Schema.AvailableListEntry.entry(nil, %{id: entry.id}, nil)
+            end
+        end
+    end
+  end
+
+  @doc """
+  Graphql resolver that removes an existing mod value from an existing
+  available list entry
+  """
+  @spec remove_mod_value_from_list_entry(
+          any,
+          %{entry_mod_value_input: map()},
+          any
+        ) :: {:error, Ecto.Changeset.t()} | {:ok, map()}
+  def remove_mod_value_from_list_entry(
+        _parent,
+        %{entry_mod_value_input: %{entry: entry, mod_value: mod_value}},
+        _resolution
+      ) do
+    case AidTaxonomy.get_mod_value(mod_value) do
+      nil ->
+        {:error, @mod_value_not_found}
+
+      mod_value ->
+        case Aid.get_entry(entry, item_preload: :with_mod_values) do
+          :not_found ->
+            {:error, @entry_not_found}
+
+          {:ok, entry} ->
+            with :ok <- Aid.remove_mod_value_from_entry(mod_value, entry) do
+              # We need to return the entry as an available list entry
+              # and it has to be linked to its available list, for completeness
+              # with other apis. Since we have this convention
+              # already implemented in the available list schema module, we can
+              # simply reuse it.
+              FerryApi.Schema.AvailableListEntry.entry(nil, %{id: entry.id}, nil)
+            end
+        end
+    end
+  end
+end

--- a/lib/ferry_api/available_list_entry_type.ex
+++ b/lib/ferry_api/available_list_entry_type.ex
@@ -9,6 +9,7 @@ defmodule FerryApi.Schema.AvailableListEntryType do
 
     field :list, non_null(:available_list)
     field :item, non_null(:item)
+    field :mod_values, list_of(:list_entry_mod_value)
   end
 
   payload_object(:available_list_entry_payload, :available_list_entry)

--- a/lib/ferry_api/list_entry_mod_value_schema.ex
+++ b/lib/ferry_api/list_entry_mod_value_schema.ex
@@ -1,0 +1,8 @@
+defmodule FerryApi.Schema.ListEntryModValue do
+  use Absinthe.Schema.Notation
+
+  input_object :entry_mod_value_input do
+    field :entry, non_null(:id)
+    field :mod_value, non_null(:id)
+  end
+end

--- a/lib/ferry_api/list_entry_mod_value_type.ex
+++ b/lib/ferry_api/list_entry_mod_value_type.ex
@@ -1,0 +1,8 @@
+defmodule FerryApi.Schema.ListEntryModValueType do
+  use Absinthe.Schema.Notation
+
+  object :list_entry_mod_value do
+    field :id, non_null(:id)
+    field :mod_value, non_null(:mod_value)
+  end
+end

--- a/lib/ferry_api/needs_list_entry_mod_value_schema.ex
+++ b/lib/ferry_api/needs_list_entry_mod_value_schema.ex
@@ -1,0 +1,101 @@
+defmodule FerryApi.Schema.NeedsListEntryModValue do
+  use Absinthe.Schema.Notation
+
+  import AbsintheErrorPayload.Payload
+  alias FerryApi.Middleware
+  alias Ferry.Aid
+  alias Ferry.AidTaxonomy
+
+  object :needs_list_entry_mod_value_mutations do
+    @desc "Add an existing mod value to an existing needs list entry"
+    field :add_mod_value_to_needs_list_entry, type: :needs_list_entry_payload do
+      arg(:entry_mod_value_input, non_null(:entry_mod_value_input))
+      middleware(Middleware.RequireUser)
+      resolve(&add_mod_value_to_list_entry/3)
+      middleware(&build_payload/2)
+    end
+
+    @desc "Remove an existing mod value from an existing needs list entry"
+    field :remove_mod_value_from_needs_list_entry, type: :needs_list_entry_payload do
+      arg(:entry_mod_value_input, non_null(:entry_mod_value_input))
+      middleware(Middleware.RequireUser)
+      resolve(&remove_mod_value_from_list_entry/3)
+      middleware(&build_payload/2)
+    end
+  end
+
+  @entry_not_found "entry not found"
+  @mod_value_not_found "mod value not found"
+
+  @doc """
+  Graphql resolver that adds a new mod value to an existing
+  needs list entry
+  """
+  @spec add_mod_value_to_list_entry(
+          any,
+          %{entry_mod_value_input: map()},
+          any
+        ) :: {:error, Ecto.Changeset.t()} | {:ok, map()}
+  def add_mod_value_to_list_entry(
+        _parent,
+        %{entry_mod_value_input: %{entry: entry, mod_value: mod_value}},
+        _resolution
+      ) do
+    case AidTaxonomy.get_mod_value(mod_value) do
+      nil ->
+        {:error, @mod_value_not_found}
+
+      mod_value ->
+        case Aid.get_entry(entry, item_preload: :with_mod_values) do
+          :not_found ->
+            {:error, @entry_not_found}
+
+          {:ok, entry} ->
+            with :ok <- Aid.add_mod_value_to_entry(mod_value, entry) do
+              # We need to return the entry as an needs list entry
+              # and it has to be linked to its needs list, for completeness
+              # with other apis. Since we have this convention
+              # already implemented in the needs list schema module, we can
+              # simply reuse it.
+              FerryApi.Schema.NeedsListEntry.entry(nil, %{id: entry.id}, nil)
+            end
+        end
+    end
+  end
+
+  @doc """
+  Graphql resolver that removes an existing mod value from an existing
+  needs list entry
+  """
+  @spec remove_mod_value_from_list_entry(
+          any,
+          %{entry_mod_value_input: map()},
+          any
+        ) :: {:error, Ecto.Changeset.t()} | {:ok, map()}
+  def remove_mod_value_from_list_entry(
+        _parent,
+        %{entry_mod_value_input: %{entry: entry, mod_value: mod_value}},
+        _resolution
+      ) do
+    case AidTaxonomy.get_mod_value(mod_value) do
+      nil ->
+        {:error, @mod_value_not_found}
+
+      mod_value ->
+        case Aid.get_entry(entry, item_preload: :with_mod_values) do
+          :not_found ->
+            {:error, @entry_not_found}
+
+          {:ok, entry} ->
+            with :ok <- Aid.remove_mod_value_from_entry(mod_value, entry) do
+              # We need to return the entry as an needs list entry
+              # and it has to be linked to its needs list, for completeness
+              # with other apis. Since we have this convention
+              # already implemented in the needs list schema module, we can
+              # simply reuse it.
+              FerryApi.Schema.NeedsListEntry.entry(nil, %{id: entry.id}, nil)
+            end
+        end
+    end
+  end
+end

--- a/lib/ferry_api/needs_list_entry_type.ex
+++ b/lib/ferry_api/needs_list_entry_type.ex
@@ -9,6 +9,7 @@ defmodule FerryApi.Schema.NeedsListEntryType do
 
     field :list, non_null(:needs_list)
     field :item, non_null(:item)
+    field :mod_values, list_of(:list_entry_mod_value)
   end
 
   payload_object(:needs_list_entry_payload, :needs_list_entry)

--- a/lib/ferry_api/schema.ex
+++ b/lib/ferry_api/schema.ex
@@ -45,6 +45,9 @@ defmodule FerryApi.Schema do
   import_types(FerryApi.Schema.NeedsListType)
   import_types(FerryApi.Schema.NeedsList)
 
+  import_types(FerryApi.Schema.ListEntryModValueType)
+  import_types(FerryApi.Schema.ListEntryModValue)
+
   import_types(FerryApi.Schema.NeedsListEntryType)
   import_types(FerryApi.Schema.NeedsListEntry)
 
@@ -53,6 +56,11 @@ defmodule FerryApi.Schema do
 
   import_types(FerryApi.Schema.AvailableListEntryType)
   import_types(FerryApi.Schema.AvailableListEntry)
+
+  import_types(FerryApi.Schema.ListEntryModValue)
+
+  import_types(FerryApi.Schema.AvailableListEntryModValue)
+  import_types(FerryApi.Schema.NeedsListEntryModValue)
 
   # Queries
   # ------------------------------------------------------------
@@ -90,8 +98,10 @@ defmodule FerryApi.Schema do
     import_fields(:package_mutations)
     import_fields(:needs_list_mutations)
     import_fields(:needs_list_entry_mutations)
+    import_fields(:needs_list_entry_mod_value_mutations)
     import_fields(:available_list_mutations)
     import_fields(:available_list_entry_mutations)
+    import_fields(:available_list_entry_mod_value_mutations)
   end
 
   @sources [

--- a/priv/repo/migrations/20201017120400_add_list_entries_mod_values_table.exs
+++ b/priv/repo/migrations/20201017120400_add_list_entries_mod_values_table.exs
@@ -1,0 +1,15 @@
+defmodule Ferry.Repo.Migrations.AddListEntriesModValuesTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:aid__list_entries__mod_values) do
+      add :entry_id, references(:aid__list_entries, on_delete: :delete_all)
+      add :mod_value_id, references(:aid__mod_values, on_delete: :nothing)
+      timestamps()
+    end
+
+    create unique_index(:aid__list_entries__mod_values, [:entry_id, :mod_value_id],
+             name: :distinct_mod_values_per_list_entry
+           )
+  end
+end

--- a/test/ferry_api/available_list_entry_mod_value_api_test.exs
+++ b/test/ferry_api/available_list_entry_mod_value_api_test.exs
@@ -1,0 +1,57 @@
+defmodule Ferry.AvailableListEntryModValueApiTest do
+  use FerryWeb.ConnCase, async: true
+  import Ferry.ApiClient.{AvailableListEntryModValue}
+
+  setup context do
+    insert(:user)
+    |> mock_sign_in
+
+    {:ok, context} = Ferry.Fixture.AvailableListWithEntry.setup(context)
+    {:ok, context} = Ferry.Fixture.ModWithModValues.setup(context)
+    Ferry.Fixture.ItemWithMod.setup(context)
+  end
+
+  describe "available list entry mod value graphql api" do
+    test "adds and removes existing mod values to existing available list entries", %{
+      conn: conn,
+      entry: entry,
+      small: small
+    } do
+      %{
+        "data" => %{
+          "addModValueToAvailableListEntry" => %{
+            "successful" => true,
+            "messages" => [],
+            "result" => %{
+              "id" => _,
+              "amount" => 1,
+              "modValues" => [%{"modValue" => %{"id" => ^small}}]
+            }
+          }
+        }
+      } =
+        add_mod_value_to_available_list_entry(conn, %{
+          entry: entry,
+          mod_value: small
+        })
+
+      %{
+        "data" => %{
+          "removeModValueFromAvailableListEntry" => %{
+            "successful" => true,
+            "messages" => [],
+            "result" => %{
+              "id" => _,
+              "amount" => 1,
+              "modValues" => []
+            }
+          }
+        }
+      } =
+        remove_mod_value_from_available_list_entry(conn, %{
+          entry: entry,
+          mod_value: small
+        })
+    end
+  end
+end

--- a/test/ferry_api/needs_list_api_test.exs
+++ b/test/ferry_api/needs_list_api_test.exs
@@ -6,7 +6,7 @@ defmodule Ferry.NeedsListApiTest do
     insert(:user)
     |> mock_sign_in
 
-    Ferry.Fixture.NeedsWithEntry.setup(context)
+    Ferry.Fixture.NeedsListWithEntry.setup(context)
   end
 
   describe "needs list graphql api" do

--- a/test/ferry_api/needs_list_entry_api_test.exs
+++ b/test/ferry_api/needs_list_entry_api_test.exs
@@ -6,7 +6,7 @@ defmodule Ferry.NeedsListEntryApiTest do
     insert(:user)
     |> mock_sign_in
 
-    Ferry.Fixture.NeedsWithEntry.setup(context)
+    Ferry.Fixture.NeedsListWithEntry.setup(context)
   end
 
   describe "needs list entry graphql api" do

--- a/test/ferry_api/needs_list_entry_mod_value_api_test.exs
+++ b/test/ferry_api/needs_list_entry_mod_value_api_test.exs
@@ -1,0 +1,57 @@
+defmodule Ferry.NeedsListEntryModValueApiTest do
+  use FerryWeb.ConnCase, async: true
+  import Ferry.ApiClient.{NeedsListEntryModValue}
+
+  setup context do
+    insert(:user)
+    |> mock_sign_in
+
+    {:ok, context} = Ferry.Fixture.NeedsListWithEntry.setup(context)
+    {:ok, context} = Ferry.Fixture.ModWithModValues.setup(context)
+    Ferry.Fixture.ItemWithMod.setup(context)
+  end
+
+  describe "needs list entry mod value graphql api" do
+    test "adds and removes existing mod values to existing needs list entries", %{
+      conn: conn,
+      entry: entry,
+      small: small
+    } do
+      %{
+        "data" => %{
+          "addModValueToNeedsListEntry" => %{
+            "successful" => true,
+            "messages" => [],
+            "result" => %{
+              "id" => _,
+              "amount" => 1,
+              "modValues" => [%{"modValue" => %{"id" => ^small}}]
+            }
+          }
+        }
+      } =
+        add_mod_value_to_needs_list_entry(conn, %{
+          entry: entry,
+          mod_value: small
+        })
+
+      %{
+        "data" => %{
+          "removeModValueFromNeedsListEntry" => %{
+            "successful" => true,
+            "messages" => [],
+            "result" => %{
+              "id" => _,
+              "amount" => 1,
+              "modValues" => []
+            }
+          }
+        }
+      } =
+        remove_mod_value_from_needs_list_entry(conn, %{
+          entry: entry,
+          mod_value: small
+        })
+    end
+  end
+end

--- a/test/support/api_client/available_list_entry_mod_value.ex
+++ b/test/support/api_client/available_list_entry_mod_value.ex
@@ -1,0 +1,100 @@
+defmodule Ferry.ApiClient.AvailableListEntryModValue do
+  @moduledoc """
+  Helper module that provides with a convenience GraphQL client api
+  for dealing with Entries in tests.
+  """
+
+  import Ferry.ApiClient.GraphCase
+
+  @doc """
+  Adds a mod value to an existing available list entry
+
+  """
+  @spec add_mod_value_to_available_list_entry(Plug.Conn.t(), map()) :: map()
+  def add_mod_value_to_available_list_entry(conn, attrs) do
+    graphql(conn, """
+      mutation {
+        addModValueToAvailableListEntry (
+          entryModValueInput: {
+            entry: "#{attrs.entry}",
+            modValue: "#{attrs.mod_value}"
+          }
+        ) {
+          successful,
+          messages { field, message },
+          result {
+            id,
+            list {
+              id
+            },
+            amount,
+            modValues {
+              modValue {
+                id,
+                value,
+                mod {
+                  id,
+                  name
+                }
+              },
+            },
+            item {
+              id,
+              name
+              category {
+                id,
+                name
+              }
+            }
+          }
+        }
+      }
+    """)
+  end
+
+  @doc """
+  Removes a mod value from an existing available list entry
+
+  """
+  @spec remove_mod_value_from_available_list_entry(Plug.Conn.t(), map()) :: map()
+  def remove_mod_value_from_available_list_entry(conn, attrs) do
+    graphql(conn, """
+      mutation {
+        removeModValueFromAvailableListEntry (
+          entryModValueInput: {
+            entry: "#{attrs.entry}",
+            modValue: "#{attrs.mod_value}"
+          }
+        ) {
+          successful,
+          messages { field, message },
+          result {
+            id,
+            list {
+              id
+            },
+            amount,
+            modValues {
+              modValue {
+                id,
+                value,
+                mod {
+                  id,
+                  name
+                }
+              },
+            },
+            item {
+              id,
+              name
+              category {
+                id,
+                name
+              }
+            }
+          }
+        }
+      }
+    """)
+  end
+end

--- a/test/support/api_client/needs_list_entry_mod_value.ex
+++ b/test/support/api_client/needs_list_entry_mod_value.ex
@@ -1,0 +1,100 @@
+defmodule Ferry.ApiClient.NeedsListEntryModValue do
+  @moduledoc """
+  Helper module that provides with a convenience GraphQL client api
+  for dealing with Entries in tests.
+  """
+
+  import Ferry.ApiClient.GraphCase
+
+  @doc """
+  Adds a mod value to an existing needs list entry
+
+  """
+  @spec add_mod_value_to_needs_list_entry(Plug.Conn.t(), map()) :: map()
+  def add_mod_value_to_needs_list_entry(conn, attrs) do
+    graphql(conn, """
+      mutation {
+        addModValueToNeedsListEntry (
+          entryModValueInput: {
+            entry: "#{attrs.entry}",
+            modValue: "#{attrs.mod_value}"
+          }
+        ) {
+          successful,
+          messages { field, message },
+          result {
+            id,
+            list {
+              id
+            },
+            amount,
+            modValues {
+              modValue {
+                id,
+                value,
+                mod {
+                  id,
+                  name
+                }
+              },
+            },
+            item {
+              id,
+              name
+              category {
+                id,
+                name
+              }
+            }
+          }
+        }
+      }
+    """)
+  end
+
+  @doc """
+  Removes a mod value from an existing needs list entry
+
+  """
+  @spec remove_mod_value_from_needs_list_entry(Plug.Conn.t(), map()) :: map()
+  def remove_mod_value_from_needs_list_entry(conn, attrs) do
+    graphql(conn, """
+      mutation {
+        removeModValueFromNeedsListEntry (
+          entryModValueInput: {
+            entry: "#{attrs.entry}",
+            modValue: "#{attrs.mod_value}"
+          }
+        ) {
+          successful,
+          messages { field, message },
+          result {
+            id,
+            list {
+              id
+            },
+            amount,
+            modValues {
+              modValue {
+                id,
+                value,
+                mod {
+                  id,
+                  name
+                }
+              },
+            },
+            item {
+              id,
+              name
+              category {
+                id,
+                name
+              }
+            }
+          }
+        }
+      }
+    """)
+  end
+end

--- a/test/support/fixture/item_with_mod.ex
+++ b/test/support/fixture/item_with_mod.ex
@@ -1,0 +1,19 @@
+defmodule Ferry.Fixture.ItemWithMod do
+  import Ferry.ApiClient.Mod
+
+  def setup(%{conn: conn, item: item, size: mod} = context) do
+    %{
+      "data" => %{
+        "addModToItem" => %{
+          "successful" => true
+        }
+      }
+    } =
+      add_mod_to_item(conn, %{
+        item: item,
+        mod: mod
+      })
+
+    {:ok, context}
+  end
+end

--- a/test/support/fixture/mod_with_mod_values.ex
+++ b/test/support/fixture/mod_with_mod_values.ex
@@ -1,0 +1,46 @@
+defmodule Ferry.Fixture.ModWithModValues do
+  import Ferry.ApiClient.{Mod, ModValue}
+
+  def setup(%{conn: conn} = context) do
+    %{
+      "data" => %{
+        "createMod" => %{
+          "successful" => true,
+          "messages" => [],
+          "result" => %{
+            "id" => size
+          }
+        }
+      }
+    } = create_mod(conn, %{name: "size", description: "T-Shirt sizes", type: "select"})
+
+    %{
+      "data" => %{
+        "createModValue" => %{
+          "successful" => true,
+          "result" => %{
+            "id" => small
+          }
+        }
+      }
+    } = create_mod_value(conn, %{value: "small", mod: size})
+
+    %{
+      "data" => %{
+        "createModValue" => %{
+          "successful" => true,
+          "result" => %{
+            "id" => regular
+          }
+        }
+      }
+    } = create_mod_value(conn, %{value: "regular", mod: size})
+
+    {:ok,
+     Map.merge(context, %{
+       size: size,
+       small: small,
+       regular: regular
+     })}
+  end
+end

--- a/test/support/fixture/needs_list_with_entry.ex
+++ b/test/support/fixture/needs_list_with_entry.ex
@@ -1,4 +1,4 @@
-defmodule Ferry.Fixture.NeedsWithEntry do
+defmodule Ferry.Fixture.NeedsListWithEntry do
   import Ferry.ApiClient.{Group, Project, NeedsList, Category, Item, NeedsListEntry}
 
   def setup(%{conn: conn} = context) do


### PR DESCRIPTION
This PR implements an api to add/remove existing mod values to existing list entries.

This includes:

* Database migration with a new `aid__list_entries__mod_values` table.
* new `EntryMod` Ecto schema.
* new add/remove functions in `Aid` phoenix context.
* new GraphQL types and mutations to add/remove existing mod values to existing available/needs list entries.

Fixes #62 
 