### PR TITLE
Link existing addresses to projects

### DIFF
--- a/lib/ferry/locations/address.ex
+++ b/lib/ferry/locations/address.ex
@@ -46,6 +46,10 @@ defmodule Ferry.Locations.Address do
     :needs_appointment
   ]
 
+  @optional_fields [
+    :project_id
+  ]
+
   @address_types [
     "industrial",
     "residential"
@@ -54,7 +58,7 @@ defmodule Ferry.Locations.Address do
   @doc false
   def changeset(address, attrs) do
     address
-    |> cast(attrs, @required_fields)
+    |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> validate_inclusion(:type, @address_types)
     |> validate_length(:label, min: 1, max: 255)

--- a/lib/ferry/profiles/project.ex
+++ b/lib/ferry/profiles/project.ex
@@ -2,6 +2,7 @@ defmodule Ferry.Profiles.Project do
   use Ecto.Schema
   import Ecto.Changeset
   alias Ferry.Profiles.Group
+  alias Ferry.Locations.Address
 
   # alias Ferry.Locations.Address
 
@@ -12,6 +13,7 @@ defmodule Ferry.Profiles.Project do
     field :description, :string
 
     belongs_to :group, Group
+    has_many :addresses, Address, foreign_key: :project_id
 
     timestamps()
   end
@@ -23,12 +25,5 @@ defmodule Ferry.Profiles.Project do
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 255)
     |> unique_constraint(:name)
-  end
-
-  @doc false
-  def address_changeset(project, attrs) do
-    project
-    |> cast(attrs, [])
-    |> cast_assoc(:address, required: true, with: &Ferry.Locations.Address.full_changeset/2)
   end
 end

--- a/lib/ferry_api/project_type.ex
+++ b/lib/ferry_api/project_type.ex
@@ -8,6 +8,7 @@ defmodule FerryApi.Schema.ProjectType do
     field :name, non_null(:string)
     field :description, non_null(:string)
     field :group, non_null(:group)
+    field :addresses, list_of(:address)
   end
 
   payload_object(:project_payload, :project)

--- a/priv/repo/migrations/20201020220300_remove_address_unique_owner.exs
+++ b/priv/repo/migrations/20201020220300_remove_address_unique_owner.exs
@@ -1,0 +1,7 @@
+defmodule Ferry.Repo.Migrations.RemoveAddressUniqueOwner do
+  use Ecto.Migration
+
+  def change do
+    drop constraint(:addresses, :has_exactly_one_owner)
+  end
+end

--- a/test/ferry_api/project_address_api_test.exs
+++ b/test/ferry_api/project_address_api_test.exs
@@ -1,0 +1,80 @@
+defmodule Ferry.ProjectAddressApiTest do
+  use FerryWeb.ConnCase, async: true
+  import Ferry.ApiClient.Address
+
+  setup context do
+    insert(:user)
+    |> mock_sign_in
+
+    Ferry.Fixture.GroupProjectAddress.setup(context)
+  end
+
+  test "adds address to project", %{conn: conn, project: project, address: address} do
+    %{
+      "data" => %{
+        "addAddressToProject" => %{
+          "successful" => true,
+          "messages" => [],
+          "result" => %{
+            "id" => ^project,
+            "addresses" => [
+              %{"id" => ^address}
+            ]
+          }
+        }
+      }
+    } = add_address_to_project(conn, project, address)
+  end
+
+  test "does not add an address that does not belong to the group", %{
+    conn: conn,
+    project: project,
+    other_address: address
+  } do
+    %{
+      "data" => %{
+        "addAddressToProject" => %{
+          "successful" => false,
+          "messages" => [error]
+        }
+      }
+    } = add_address_to_project(conn, project, address)
+
+    assert "address does not belong to the project's group" == error["message"]
+  end
+
+  test "removes address from project", %{conn: conn, project: project, address: address} do
+    %{
+      "data" => %{
+        "addAddressToProject" => %{
+          "successful" => true,
+          "messages" => []
+        }
+      }
+    } = add_address_to_project(conn, project, address)
+
+    %{
+      "data" => %{
+        "removeAddressFromProject" => %{
+          "successful" => true,
+          "messages" => [],
+          "result" => %{
+            "addresses" => []
+          }
+        }
+      }
+    } = remove_address_from_project(conn, project, address)
+
+    %{
+      "data" => %{
+        "removeAddressFromProject" => %{
+          "successful" => true,
+          "messages" => [],
+          "result" => %{
+            "addresses" => []
+          }
+        }
+      }
+    } = remove_address_from_project(conn, project, address)
+  end
+end

--- a/test/support/api_client/address.ex
+++ b/test/support/api_client/address.ex
@@ -142,4 +142,58 @@ defmodule Ferry.ApiClient.Address do
     }
     """)
   end
+
+  @doc """
+  GraphQL mutation that adds an existing address to a given
+  project.
+
+  The mutation returns the project and its current list of addresses
+  """
+  @spec add_address_to_project(Plug.Conn.t(), String.t(), String.t()) :: map()
+  def add_address_to_project(conn, project, address) do
+    graphql(conn, """
+    mutation {
+      addAddressToProject(project: "#{project}", address: "#{address}") {
+        successful,
+        messages {
+          field,
+          message
+        },
+        result {
+          id,
+          addresses {
+            id
+          }
+        }
+      }
+    }
+    """)
+  end
+
+  @doc """
+  GraphQL mutation that removes an existing address from a given
+  project.
+
+  The mutation returns the project and its current list of addresses
+  """
+  @spec remove_address_from_project(Plug.Conn.t(), String.t(), String.t()) :: map()
+  def remove_address_from_project(conn, project, address) do
+    graphql(conn, """
+    mutation {
+      removeAddressFromProject(project: "#{project}", address: "#{address}") {
+        successful,
+        messages {
+          field,
+          message
+        },
+        result {
+          id,
+          addresses {
+            id
+          }
+        }
+      }
+    }
+    """)
+  end
 end

--- a/test/support/fixture/group_project_address.ex
+++ b/test/support/fixture/group_project_address.ex
@@ -1,0 +1,80 @@
+defmodule Ferry.Fixture.GroupProjectAddress do
+  import Ferry.ApiClient.{Group, Project, Address}
+
+  def setup(%{conn: conn} = context) do
+    %{
+      "data" => %{
+        "createGroup" => %{
+          "successful" => true,
+          "result" => %{
+            "id" => group
+          }
+        }
+      }
+    } = create_simple_group(conn, %{name: "a group"})
+
+    %{
+      "data" => %{
+        "createGroup" => %{
+          "successful" => true,
+          "result" => %{
+            "id" => other_group
+          }
+        }
+      }
+    } = create_simple_group(conn, %{name: "other group"})
+
+    %{
+      "data" => %{
+        "createProject" => %{
+          "successful" => true,
+          "messages" => [],
+          "result" => %{
+            "id" => project,
+            "name" => "test project",
+            "description" => "test description for test project"
+          }
+        }
+      }
+    } =
+      create_project(conn, %{
+        group: group,
+        name: "test project",
+        description: "test description for test project"
+      })
+
+    %{
+      "data" => %{
+        "createAddress" => %{
+          "successful" => true,
+          "messages" => [],
+          "result" => %{
+            "id" => address
+          }
+        }
+      }
+    } = create_address(conn, %{group: group, label: "test"})
+
+    %{
+      "data" => %{
+        "createAddress" => %{
+          "successful" => true,
+          "messages" => [],
+          "result" => %{
+            "id" => other_address
+          }
+        }
+      }
+    } = create_address(conn, %{group: other_group, label: "test"})
+
+    context =
+      Map.merge(context, %{
+        group: group,
+        project: project,
+        address: address,
+        other_address: other_address
+      })
+
+    {:ok, context}
+  end
+end


### PR DESCRIPTION
This PR implements a GraphQL API so that we can link existing addresses to projects.

Fixes: #74 