### PR TITLE
Current needs by addresses graphql api

### DIFF
--- a/lib/ferry/aid/entry.ex
+++ b/lib/ferry/aid/entry.ex
@@ -53,14 +53,26 @@ defmodule Ferry.Aid.Entry do
   """
   @spec eq?(t(), t()) :: true | false
   def eq?(one, another) do
-    one.item.id == another.item.id &&
-      one.item.mods |> Enum.map(&id_from_struct/1) |> Enum.sort() ==
-        another.item.mods |> Enum.map(&id_from_struct/1) |> Enum.sort() &&
-      one.mod_values |> Enum.map(&id_from_struct/1) |> Enum.sort() ==
-        another.mod_values |> Enum.map(&id_from_struct/1) |> Enum.sort()
+    one = comparison_opts(one)
+    another = comparison_opts(another)
+    one == another
   end
 
-  defp id_from_struct(%{id: id}), do: id
+  # Builds the structure that defines how two entries
+  # are compared
+  defp comparison_opts(entry) do
+    [
+      item: entry.item.id,
+      mods: entry.item.mods |> Enum.map(&id_from/1) |> Enum.sort(),
+      values:
+        entry.mod_values
+        |> Enum.map(fn mod_value -> mod_value.mod_value end)
+        |> Enum.map(&id_from/1)
+        |> Enum.sort()
+    ]
+  end
+
+  defp id_from(%{id: id}), do: id
 
   # TODO: handle moving entries between lists in a separate changeset since that could get tricky, as the new list may have th same item w/ the same mod values already
 end

--- a/test/ferry_api/needs_list_by_addresses_test.exs
+++ b/test/ferry_api/needs_list_by_addresses_test.exs
@@ -1,0 +1,37 @@
+defmodule Ferry.NeedsListByAddresses do
+  use FerryWeb.ConnCase, async: true
+  import Ferry.ApiClient.NeedsListByAddresses
+  import Ferry.Expectations.ListEntry
+
+  setup context do
+    insert(:user)
+    |> mock_sign_in
+
+    Ferry.Fixture.NeedsListAggregation.single_entry(context)
+  end
+
+  describe "needs list by addresses" do
+    test "aggregates amounts", %{
+      conn: conn,
+      london: london,
+      leeds: leeds
+    } do
+      %{
+        "data" => %{
+          "currentNeedsListByAddresses" => %{
+            "entries" => entries
+          }
+        }
+      } = get_current_needs_list_by_addresses(conn, [london.address.id, leeds.address.id])
+
+      assert_entry(
+        %{
+          amount: 8,
+          item: "shirt",
+          mods: %{size: "large", color: "red"}
+        },
+        entries
+      )
+    end
+  end
+end

--- a/test/support/api_client/needs_list_by_addresses.ex
+++ b/test/support/api_client/needs_list_by_addresses.ex
@@ -1,0 +1,41 @@
+defmodule Ferry.ApiClient.NeedsListByAddresses do
+  @moduledoc """
+  Helper module that provides with a convenience GraphQL client api
+  for dealing with Needs Lists by Addresses in tests
+  """
+
+  import Ferry.ApiClient.GraphCase
+
+  @doc """
+  Run a GraphQL query that returns an aggregated needs list
+  for a list of address ids. The needs list is returned for the current date
+  """
+  @spec get_current_needs_list_by_addresses(Plug.Conn.t(), [String.t()]) :: map()
+  def get_current_needs_list_by_addresses(conn, ids) do
+    ids = Enum.join(ids, ",")
+
+    graphql(conn, """
+    {
+      currentNeedsListByAddresses(addresses: [#{ids}]) {
+        entries {
+          amount,
+          item {
+            name,
+            category {
+              name
+            },
+          },
+          modValues {
+            modValue{
+              value,
+              mod {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+    """)
+  end
+end

--- a/test/support/expectations/list_entry.ex
+++ b/test/support/expectations/list_entry.ex
@@ -1,0 +1,34 @@
+defmodule Ferry.Expectations.ListEntry do
+  @moduledoc """
+  Convenience module to express expectations on list entries
+  """
+  import ExUnit.Assertions
+
+  @doc """
+  Inspects the given list of entries, and looks for one that verifies
+  the given specification in terms of amount, item name and mod values.
+  """
+  def assert_entry(spec, entries) do
+    with :not_found <-
+           Enum.find(entries, :not_found, fn entry ->
+             matches?(spec, entry)
+           end) do
+      flunk("Expected entry #{inspect(spec, pretty: true)} in #{inspect(entries, pretty: true)}")
+    end
+  end
+
+  # This function guard is designed to inspect graphql entries
+  defp matches?(%{amount: amount, item: item, mods: expected_mod_values}, %{
+         "amount" => amount,
+         "item" => %{"category" => %{"name" => _}, "name" => item},
+         "modValues" => mod_values
+       }) do
+    mod_values
+    |> Enum.filter(fn %{"modValue" => %{"mod" => %{"name" => name}, "value" => value}} ->
+      value == Map.get(expected_mod_values, String.to_existing_atom(name), nil)
+    end)
+    |> Enum.count() == length(mod_values)
+  end
+
+  defp matches?(_, _), do: false
+end

--- a/test/support/fixture/needs_list_aggregation.ex
+++ b/test/support/fixture/needs_list_aggregation.ex
@@ -1,0 +1,210 @@
+defmodule Ferry.Fixture.NeedsListAggregation do
+  @moduledoc """
+  A helper module that sets up data so that we can test
+  needs list aggregations
+  """
+
+  alias Ferry.Profiles.Project
+  alias Ferry.Locations
+  alias Ferry.Locations.Address
+  alias Ferry.Profiles
+  alias Ferry.AidTaxonomy
+  alias Ferry.Aid
+
+  defp needs_setup(context) do
+    {:ok, london_group} = create_group("london")
+
+    {:ok, leeds_group} = create_group("leeds")
+
+    {:ok, london_project} = create_project(london_group)
+    {:ok, leeds_project} = create_project(leeds_group)
+
+    {:ok, london_address} =
+      Locations.create_address(london_group, %{
+        label: "default",
+        street: "Harp Lane",
+        city: "London",
+        province: "London",
+        country_code: "GB",
+        postal_code: "EC3R",
+        opening_hour: "08:00",
+        closing_hour: "20:00",
+        type: "residential",
+        has_loading_equipment: false,
+        has_unloading_equipment: false,
+        needs_appointment: false
+      })
+
+    {:ok, leeds_address} =
+      Locations.create_address(leeds_group, %{
+        label: "default",
+        street: "Vicar Lane",
+        city: "Leeds",
+        province: "Leeds",
+        country_code: "GB",
+        postal_code: "LS17JH",
+        opening_hour: "08:00",
+        closing_hour: "20:00",
+        type: "residential",
+        has_loading_equipment: false,
+        has_unloading_equipment: false,
+        needs_appointment: false
+      })
+
+    {:ok, _} = Profiles.add_address_to_project(leeds_project, leeds_address)
+    {:ok, _} = Profiles.add_address_to_project(london_project, london_address)
+
+    # Reload the addresses, so that they include their relation
+    # to the project
+    %Address{project: %Project{}} = leeds_address = Locations.get_address(leeds_address.id)
+    %Address{project: %Project{}} = london_address = Locations.get_address(london_address.id)
+
+    {:ok, clothes} =
+      AidTaxonomy.create_category(%{
+        name: "clothes",
+        description: "clothes"
+      })
+
+    {:ok, shirt} =
+      AidTaxonomy.create_item(clothes, %{
+        name: "shirt"
+      })
+
+    {:ok, color} =
+      AidTaxonomy.create_mod(%{
+        name: "color",
+        type: "select",
+        description: "color"
+      })
+
+    {:ok, size} =
+      AidTaxonomy.create_mod(%{
+        name: "size",
+        type: "select",
+        description: "size"
+      })
+
+    :ok = AidTaxonomy.add_mod_to_item(color, shirt)
+    :ok = AidTaxonomy.add_mod_to_item(size, shirt)
+
+    {:ok, red} =
+      AidTaxonomy.create_mod_value(color, %{
+        value: "red"
+      })
+
+    {:ok, yellow} =
+      AidTaxonomy.create_mod_value(color, %{
+        value: "yellow"
+      })
+
+    {:ok, small} =
+      AidTaxonomy.create_mod_value(size, %{
+        value: "small"
+      })
+
+    {:ok, large} =
+      AidTaxonomy.create_mod_value(size, %{
+        value: "large"
+      })
+
+    from = DateTime.utc_now()
+    to = DateTime.utc_now() |> DateTime.add(24 * 3600, :second)
+
+    {:ok, needs_london} = Aid.create_needs_list(london_project, %{from: from, to: to})
+    {:ok, needs_leeds} = Aid.create_needs_list(leeds_project, %{from: from, to: to})
+
+    context =
+      Map.merge(context, %{
+        red: red,
+        yellow: yellow,
+        small: small,
+        large: large,
+        shirt: shirt,
+        london: %{
+          needs: needs_london,
+          address: london_address,
+          project: london_project,
+          group: london_group
+        },
+        leeds: %{
+          needs: needs_leeds,
+          address: leeds_address,
+          project: leeds_project,
+          group: leeds_group
+        }
+      })
+
+    {:ok, context}
+  end
+
+  def single_entry(context) do
+    {:ok,
+     %{
+       shirt: shirt,
+       red: red,
+       large: large,
+       london: london,
+       leeds: leeds
+     } = context} = needs_setup(context)
+
+    {:ok, large_red_shirts_london} = Aid.create_entry(london.needs, shirt, %{amount: 4})
+    :ok = Aid.add_mod_value_to_entry(large, large_red_shirts_london)
+    :ok = Aid.add_mod_value_to_entry(red, large_red_shirts_london)
+
+    {:ok, large_red_shirts_leeds} = Aid.create_entry(leeds.needs, shirt, %{amount: 4})
+    :ok = Aid.add_mod_value_to_entry(large, large_red_shirts_leeds)
+    :ok = Aid.add_mod_value_to_entry(red, large_red_shirts_leeds)
+
+    {:ok, context}
+  end
+
+  def three_entries(context) do
+    {:ok,
+     %{
+       shirt: shirt,
+       red: red,
+       yellow: yellow,
+       large: large,
+       london: london,
+       leeds: leeds
+     } = context} = needs_setup(context)
+
+    {:ok, red_shirts_london} = Aid.create_entry(london.needs, shirt, %{amount: 1})
+    :ok = Aid.add_mod_value_to_entry(red, red_shirts_london)
+
+    {:ok, yellow_shirts_leeds} = Aid.create_entry(leeds.needs, shirt, %{amount: 3})
+    :ok = Aid.add_mod_value_to_entry(yellow, yellow_shirts_leeds)
+
+    {:ok, large_red_shirts_london} = Aid.create_entry(london.needs, shirt, %{amount: 4})
+    :ok = Aid.add_mod_value_to_entry(large, large_red_shirts_london)
+    :ok = Aid.add_mod_value_to_entry(red, large_red_shirts_london)
+
+    {:ok, large_red_shirts_leeds} = Aid.create_entry(leeds.needs, shirt, %{amount: 4})
+    :ok = Aid.add_mod_value_to_entry(large, large_red_shirts_leeds)
+    :ok = Aid.add_mod_value_to_entry(red, large_red_shirts_leeds)
+
+    {:ok, context}
+  end
+
+  defp create_group(name) do
+    Profiles.create_group(%{
+      name: name,
+      slug: name,
+      description: name,
+      slack_channel_name: name,
+      request_form: "https://nodomain.com/forms",
+      request_form_results: "https://nodomain.com/forms",
+      volunteer_form: "https://nodomain.com/forms",
+      volunteer_form_results: "https://nodomain.com/forms",
+      donation_form: "https://nodomain.com/forms",
+      donation_form_results: "https://nodomain.com/forms"
+    })
+  end
+
+  defp create_project(group) do
+    Profiles.create_project(group, %{
+      name: group.name,
+      description: group.name
+    })
+  end
+end


### PR DESCRIPTION
This PR implements a graphql query named `currentNeedsByAddresses` that returns an aggregated needs list for a given list of address ids.

Also refactors some test fixtures, introduces a simple expectation framework on aggregated entries and fixes some bugs from previous PRs https://github.com/distributeaid/toolbox/pull/75 and https://github.com/distributeaid/toolbox/pull/80


Fixes https://github.com/distributeaid/toolbox/issues/68