### PR TITLE
Aggregated Needs lists by addresses and date range GraphQL API

### DIFF
--- a/test/ferry_api/needs_list_by_addresses_test.exs
+++ b/test/ferry_api/needs_list_by_addresses_test.exs
@@ -22,7 +22,10 @@ defmodule Ferry.NeedsListByAddresses do
             "entries" => entries
           }
         }
-      } = get_current_needs_list_by_addresses(conn, [london.address.id, leeds.address.id])
+      } =
+        get_current_needs_list_by_addresses(conn, %{
+          addresses: [london.address.id, leeds.address.id]
+        })
 
       assert_entry(
         %{
@@ -32,6 +35,41 @@ defmodule Ferry.NeedsListByAddresses do
         },
         entries
       )
+
+      %{
+        "data" => %{
+          "needsListByAddresses" => %{
+            "entries" => entries
+          }
+        }
+      } =
+        get_needs_list_by_addresses(conn, %{
+          addresses: [london.address.id, leeds.address.id],
+          from: DateTime.utc_now() |> DateTime.add(-24 * 3600, :second),
+          to: DateTime.utc_now() |> DateTime.add(24 * 3600, :second)
+        })
+
+      assert_entry(
+        %{
+          amount: 8,
+          item: "shirt",
+          mods: %{size: "large", color: "red"}
+        },
+        entries
+      )
+
+      %{
+        "data" => %{
+          "needsListByAddresses" => %{
+            "entries" => []
+          }
+        }
+      } =
+        get_needs_list_by_addresses(conn, %{
+          addresses: [london.address.id, leeds.address.id],
+          from: DateTime.utc_now() |> DateTime.add(-48 * 3600, :second),
+          to: DateTime.utc_now() |> DateTime.add(-24 * 3600, :second)
+        })
     end
   end
 end

--- a/test/support/api_client/needs_list_by_addresses.ex
+++ b/test/support/api_client/needs_list_by_addresses.ex
@@ -10,13 +10,49 @@ defmodule Ferry.ApiClient.NeedsListByAddresses do
   Run a GraphQL query that returns an aggregated needs list
   for a list of address ids. The needs list is returned for the current date
   """
-  @spec get_current_needs_list_by_addresses(Plug.Conn.t(), [String.t()]) :: map()
-  def get_current_needs_list_by_addresses(conn, ids) do
-    ids = Enum.join(ids, ",")
+  @spec get_current_needs_list_by_addresses(Plug.Conn.t(), map()) :: map()
+  def get_current_needs_list_by_addresses(conn, attrs) do
+    ids = Enum.join(attrs.addresses, ",")
 
     graphql(conn, """
     {
       currentNeedsListByAddresses(addresses: [#{ids}]) {
+        entries {
+          amount,
+          item {
+            name,
+            category {
+              name
+            },
+          },
+          modValues {
+            modValue{
+              value,
+              mod {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+    """)
+  end
+
+  @doc """
+  Run a GraphQL query that returns an aggregated needs list
+  for a list of address ids and a date range
+  """
+  @spec get_needs_list_by_addresses(Plug.Conn.t(), map()) :: map()
+  def get_needs_list_by_addresses(conn, attrs) do
+    ids = Enum.join(attrs.addresses, ",")
+
+    from = DateTime.to_iso8601(attrs.from)
+    to = DateTime.to_iso8601(attrs.to)
+
+    graphql(conn, """
+    {
+      needsListByAddresses(addresses: [#{ids}], from: "#{from}", to: "#{to}") {
         entries {
           amount,
           item {


### PR DESCRIPTION
This PR implements a `needsListByAddresses` GraphQL query that accepts a list of address `id`s, and a `from`/`to` date range, and returns an aggregated needs list.

Related PRs:
* https://github.com/distributeaid/toolbox/pull/75
* https://github.com/distributeaid/toolbox/pull/80
* https://github.com/distributeaid/toolbox/pull/82

Fixes: https://github.com/distributeaid/toolbox/issues/68