### PR TITLE
Aggregated needs by groups GraphQL API

### DIFF
--- a/lib/ferry/profiles/profiles.ex
+++ b/lib/ferry/profiles/profiles.ex
@@ -50,14 +50,15 @@ defmodule Ferry.Profiles do
     Repo.get!(query, id)
   end
 
+  @doc """
+  Returns a group, given its id
+  """
+  @spec get_group(String.t()) :: Group.t() | nil
   def get_group(id) do
-    query = group_query(preload: [])
-    Repo.get(query, id)
-  end
-
-  def get_group(id, preload: preload) do
-    query = group_query(preload: preload)
-    Repo.get(query, id)
+    Group
+    |> preload(addresses: [:project])
+    |> preload(:projects)
+    |> Repo.get(id)
   end
 
   def get_group_by_slug(slug) do

--- a/lib/ferry_api/group_schema.ex
+++ b/lib/ferry_api/group_schema.ex
@@ -96,7 +96,7 @@ defmodule FerryApi.Schema.Group do
   end
 
   def get_group(_parent, %{id: id}, _resolution) do
-    case Profiles.get_group(id, preload: [:addresses]) do
+    case Profiles.get_group(id) do
       nil -> {:error, message: "Group not found.", id: id}
       group -> {:ok, group}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Ferry.Mixfile do
       {:phoenix_pubsub, "~> 2.0"},
       {:ecto_sql, "~> 3.0", override: true},
       {:phoenix_ecto, "~> 4.1"},
-      {:postgrex, ">= 0.0.0"},
+      {:postgrex, ">= 0.15.6"},
       {:phoenix_html, "~> 2.13"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:gettext, "~> 0.18"},

--- a/test/ferry_api/needs_list_by_groups_test.exs
+++ b/test/ferry_api/needs_list_by_groups_test.exs
@@ -1,0 +1,75 @@
+defmodule Ferry.NeedsListByGroups do
+  use FerryWeb.ConnCase, async: true
+  import Ferry.ApiClient.NeedsListByGroups
+  import Ferry.Expectations.ListEntry
+
+  setup context do
+    insert(:user)
+    |> mock_sign_in
+
+    Ferry.Fixture.NeedsListAggregation.single_entry(context)
+  end
+
+  describe "needs list by groups" do
+    test "aggregates amounts", %{
+      conn: conn,
+      london: london,
+      leeds: leeds
+    } do
+      %{
+        "data" => %{
+          "currentNeedsListByGroups" => %{
+            "entries" => entries
+          }
+        }
+      } =
+        get_current_needs_list_by_groups(conn, %{
+          groups: [london.group.id, leeds.group.id]
+        })
+
+      assert_entry(
+        %{
+          amount: 8,
+          item: "shirt",
+          mods: %{size: "large", color: "red"}
+        },
+        entries
+      )
+
+      %{
+        "data" => %{
+          "needsListByGroups" => %{
+            "entries" => entries
+          }
+        }
+      } =
+        get_needs_list_by_groups(conn, %{
+          groups: [london.group.id, leeds.group.id],
+          from: DateTime.utc_now() |> DateTime.add(-24 * 3600, :second),
+          to: DateTime.utc_now() |> DateTime.add(24 * 3600, :second)
+        })
+
+      assert_entry(
+        %{
+          amount: 8,
+          item: "shirt",
+          mods: %{size: "large", color: "red"}
+        },
+        entries
+      )
+
+      %{
+        "data" => %{
+          "needsListByGroups" => %{
+            "entries" => []
+          }
+        }
+      } =
+        get_needs_list_by_groups(conn, %{
+          groups: [london.group.id, leeds.group.id],
+          from: DateTime.utc_now() |> DateTime.add(-48 * 3600, :second),
+          to: DateTime.utc_now() |> DateTime.add(-24 * 3600, :second)
+        })
+    end
+  end
+end

--- a/test/support/api_client/needs_list_by_groups.ex
+++ b/test/support/api_client/needs_list_by_groups.ex
@@ -1,0 +1,77 @@
+defmodule Ferry.ApiClient.NeedsListByGroups do
+  @moduledoc """
+  Helper module that provides with a convenience GraphQL client api
+  for dealing with Needs Lists by Groups in tests
+  """
+
+  import Ferry.ApiClient.GraphCase
+
+  @doc """
+  Run a GraphQL query that returns an aggregated needs list
+  for a list of address ids. The needs list is returned for the current date
+  """
+  @spec get_current_needs_list_by_groups(Plug.Conn.t(), map()) :: map()
+  def get_current_needs_list_by_groups(conn, attrs) do
+    ids = Enum.join(attrs.groups, ",")
+
+    graphql(conn, """
+    {
+      currentNeedsListByGroups(groups: [#{ids}]) {
+        entries {
+          amount,
+          item {
+            name,
+            category {
+              name
+            },
+          },
+          modValues {
+            modValue{
+              value,
+              mod {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+    """)
+  end
+
+  @doc """
+  Run a GraphQL query that returns an aggregated needs list
+  for a list of address ids and a date range
+  """
+  @spec get_needs_list_by_groups(Plug.Conn.t(), map()) :: map()
+  def get_needs_list_by_groups(conn, attrs) do
+    ids = Enum.join(attrs.groups, ",")
+
+    from = DateTime.to_iso8601(attrs.from)
+    to = DateTime.to_iso8601(attrs.to)
+
+    graphql(conn, """
+    {
+      needsListByGroups(groups: [#{ids}], from: "#{from}", to: "#{to}") {
+        entries {
+          amount,
+          item {
+            name,
+            category {
+              name
+            },
+          },
+          modValues {
+            modValue{
+              value,
+              mod {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+    """)
+  end
+end


### PR DESCRIPTION
Fixes #69 

Given a list of group ids, this new GraphQL query returns the aggregated needs list for all those groups. The implementation is pretty simple and relies on the existing aggregated needs by addresses. 