### PR TITLE
Needs list by postal codes GraphQL API

### DIFF
--- a/lib/ferry/locations/locations.ex
+++ b/lib/ferry/locations/locations.ex
@@ -69,6 +69,17 @@ defmodule Ferry.Locations do
   end
 
   @doc """
+  Gets all the addresses that match any of the given postal codes
+  """
+  @spec get_addresses_by_postal_codes([String.t()]) :: [Address.t()]
+  def get_addresses_by_postal_codes(codes) do
+    from(a in Address, where: a.postal_code in ^codes)
+    |> Repo.all()
+    |> Repo.preload(:project)
+    |> Repo.preload(:group)
+  end
+
+  @doc """
   Gets a single address.
 
   ## Examples

--- a/lib/ferry_api/needs_list_schema.ex
+++ b/lib/ferry_api/needs_list_schema.ex
@@ -54,6 +54,20 @@ defmodule FerryApi.Schema.NeedsList do
       arg(:to, non_null(:datetime))
       resolve(&needs_list_by_groups/3)
     end
+
+    @desc "Returns an aggregated current's needs list for a list of postal codes"
+    field :current_needs_list_by_postal_codes, :needs_list do
+      arg(:postal_codes, list_of(:string))
+      resolve(&current_needs_list_by_postal_codes/3)
+    end
+
+    @desc "Returns an aggregated needs list for a list of postal codes and a date range"
+    field :needs_list_by_postal_codes, :needs_list do
+      arg(:postal_codes, list_of(:string))
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      resolve(&needs_list_by_postal_codes/3)
+    end
   end
 
   input_object :needs_list_input do
@@ -198,6 +212,34 @@ defmodule FerryApi.Schema.NeedsList do
     |> Enum.map(&Ferry.Profiles.get_group(&1))
     |> Enum.filter(fn group -> group != nil end)
     |> Enum.flat_map(fn group -> group.addresses end)
+    |> Aid.get_needs_list_by_addresses(DateTime.to_date(from), DateTime.to_date(to))
+  end
+
+  @doc """
+  Resolver that returns an aggregated needs list for all addresses found for the given
+  postal codes.
+  """
+  @spec current_needs_list_by_postal_codes(any(), %{postal_codes: [String.t()]}, any()) ::
+          {:ok, map()} | {:error, term()}
+  def current_needs_list_by_postal_codes(_, %{postal_codes: codes}, _) do
+    codes
+    |> Ferry.Locations.get_addresses_by_postal_codes()
+    |> Aid.get_current_needs_list_by_addresses()
+  end
+
+  @doc """
+  Resolver that returns an aggregated needs list for all addresses found for the given
+  postal codes.
+  """
+  @spec needs_list_by_postal_codes(
+          any(),
+          %{postal_codes: [String.t()], from: DateTime.t(), to: DateTime.t()},
+          any()
+        ) ::
+          {:ok, map()} | {:error, term()}
+  def needs_list_by_postal_codes(_, %{postal_codes: codes, from: from, to: to}, _) do
+    codes
+    |> Ferry.Locations.get_addresses_by_postal_codes()
     |> Aid.get_needs_list_by_addresses(DateTime.to_date(from), DateTime.to_date(to))
   end
 

--- a/test/ferry_api/needs_list_by_postal_codes_test.exs
+++ b/test/ferry_api/needs_list_by_postal_codes_test.exs
@@ -1,0 +1,95 @@
+defmodule Ferry.NeedsListByPostalCodes do
+  use FerryWeb.ConnCase, async: true
+  import Ferry.ApiClient.NeedsListByPostalCodes
+  import Ferry.Expectations.ListEntry
+
+  setup context do
+    insert(:user)
+    |> mock_sign_in
+
+    Ferry.Fixture.NeedsListAggregation.single_entry(context)
+  end
+
+  describe "needs list by postal_codes" do
+    test "aggregates amounts", %{
+      conn: conn,
+      london: london,
+      leeds: leeds
+    } do
+      %{
+        "data" => %{
+          "currentNeedsListByPostalCodes" => %{
+            "entries" => entries
+          }
+        }
+      } =
+        get_current_needs_list_by_postal_codes(conn, %{
+          postal_codes: [london.address.postal_code, leeds.address.postal_code]
+        })
+
+      assert_entry(
+        %{
+          amount: 8,
+          item: "shirt",
+          mods: %{size: "large", color: "red"}
+        },
+        entries
+      )
+
+      %{
+        "data" => %{
+          "currentNeedsListByPostalCodes" => %{
+            "entries" => entries
+          }
+        }
+      } =
+        get_current_needs_list_by_postal_codes(conn, %{
+          postal_codes: [london.address.postal_code]
+        })
+
+      assert_entry(
+        %{
+          amount: 4,
+          item: "shirt",
+          mods: %{size: "large", color: "red"}
+        },
+        entries
+      )
+
+      %{
+        "data" => %{
+          "needsListByPostalCodes" => %{
+            "entries" => entries
+          }
+        }
+      } =
+        get_needs_list_by_postal_codes(conn, %{
+          postal_codes: [london.address.postal_code, leeds.address.postal_code],
+          from: DateTime.utc_now() |> DateTime.add(-24 * 3600, :second),
+          to: DateTime.utc_now() |> DateTime.add(24 * 3600, :second)
+        })
+
+      assert_entry(
+        %{
+          amount: 8,
+          item: "shirt",
+          mods: %{size: "large", color: "red"}
+        },
+        entries
+      )
+
+      %{
+        "data" => %{
+          "needsListByPostalCodes" => %{
+            "entries" => []
+          }
+        }
+      } =
+        get_needs_list_by_postal_codes(conn, %{
+          postal_codes: [london.address.postal_code, leeds.address.postal_code],
+          from: DateTime.utc_now() |> DateTime.add(-48 * 3600, :second),
+          to: DateTime.utc_now() |> DateTime.add(-24 * 3600, :second)
+        })
+    end
+  end
+end

--- a/test/support/api_client/needs_list_by_postal_codes.ex
+++ b/test/support/api_client/needs_list_by_postal_codes.ex
@@ -1,22 +1,22 @@
-defmodule Ferry.ApiClient.NeedsListByGroups do
+defmodule Ferry.ApiClient.NeedsListByPostalCodes do
   @moduledoc """
   Helper module that provides with a convenience GraphQL client api
-  for dealing with Needs Lists by Groups in tests
+  for dealing with Needs Lists by postal codes in tests
   """
 
   import Ferry.ApiClient.GraphCase
 
   @doc """
   Run a GraphQL query that returns an aggregated needs list
-  for a list of group ids. The needs list is returned for the current date
+  for a list of postal codes. The needs list is returned for the current date
   """
-  @spec get_current_needs_list_by_groups(Plug.Conn.t(), map()) :: map()
-  def get_current_needs_list_by_groups(conn, attrs) do
-    ids = Enum.join(attrs.groups, ",")
+  @spec get_current_needs_list_by_postal_codes(Plug.Conn.t(), map()) :: map()
+  def get_current_needs_list_by_postal_codes(conn, attrs) do
+    codes = attrs.postal_codes |> Enum.map(fn code -> "\"#{code}\"" end) |> Enum.join(",")
 
     graphql(conn, """
     {
-      currentNeedsListByGroups(groups: [#{ids}]) {
+      currentNeedsListByPostalCodes(postalCodes: [#{codes}]) {
         entries {
           amount,
           item {
@@ -41,18 +41,18 @@ defmodule Ferry.ApiClient.NeedsListByGroups do
 
   @doc """
   Run a GraphQL query that returns an aggregated needs list
-  for a list of group ids and a date range
+  for a list of postal codes and a date range
   """
-  @spec get_needs_list_by_groups(Plug.Conn.t(), map()) :: map()
-  def get_needs_list_by_groups(conn, attrs) do
-    ids = Enum.join(attrs.groups, ",")
+  @spec get_needs_list_by_postal_codes(Plug.Conn.t(), map()) :: map()
+  def get_needs_list_by_postal_codes(conn, attrs) do
+    codes = attrs.postal_codes |> Enum.map(fn code -> "\"#{code}\"" end) |> Enum.join(",")
 
     from = DateTime.to_iso8601(attrs.from)
     to = DateTime.to_iso8601(attrs.to)
 
     graphql(conn, """
     {
-      needsListByGroups(groups: [#{ids}], from: "#{from}", to: "#{to}") {
+      needsListByPostalCodes(postalCodes: [#{codes}], from: "#{from}", to: "#{to}") {
         entries {
           amount,
           item {


### PR DESCRIPTION
Fixes #70 

Implements two basic GraphQL queries to aggregate needs by postal code. The implementation is pretty simple and relies on the existing needs list aggregation for a list of addresses.