### PR TITLE
StatefulSet + Persistent Volume Claims

### DIFF
--- a/k8s.yml
+++ b/k8s.yml
@@ -26,11 +26,12 @@ spec:
     app: db
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet 
 metadata:
   name: toolbox
 spec:
-  replicas: 1
+  replicas: 2
+  serviceName: toolbox
   selector:
     matchLabels:
       app: toolbox
@@ -39,6 +40,16 @@ spec:
       labels:
         app: toolbox
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - toolbox 
+            topologyKey: "kubernetes.io/hostname"
       imagePullSecrets:
         - name: docker
       containers:
@@ -75,10 +86,31 @@ spec:
       labels:
         app: db 
     spec:
+      volumes:
+      - name: db
+          persistentVolumeClaim:
+            claimName: db-pv-claim
       containers:
         - name: db 
           image: postgres:11.2
+          imagePullPolicy: "IfNotPresent"
           ports:
             - name: http
               containerPort: 5432
               protocol: TCP
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: db
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: db-pv-claim
+  labels:
+    app: db
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 3Gi


### PR DESCRIPTION
This PR turns the toolbox deployment into a statefulset with 2 replicas (Enough for now) and also attaches a persistent volume to the Postgres database, so that we can survive sudden db restarts.

Fixes: #46 

