### PR TITLE
Simple Absinthe authorisation middleware

### DIFF
--- a/lib/ferry/accounts/accounts.ex
+++ b/lib/ferry/accounts/accounts.ex
@@ -2,7 +2,6 @@ defmodule Ferry.Accounts do
   @moduledoc """
   The Accounts context.
   """
-
   import Ecto.Query, warn: false
   alias Ferry.Repo
 
@@ -137,5 +136,16 @@ defmodule Ferry.Accounts do
            |> Repo.delete_all() do
       get_user(user.id)
     end
+  end
+
+  @doc """
+  Returns whether the given user has the given role in the given
+  group
+  """
+  @spec has_role?(User.t(), String.t(), String.t()) :: boolean()
+  def has_role?(user, group_id, role) do
+    Enum.count(user.groups, fn group ->
+      "#{group.group.id}" == "#{group_id}" && group.role == role
+    end) == 1
   end
 end

--- a/lib/ferry/profiles/profiles.ex
+++ b/lib/ferry/profiles/profiles.ex
@@ -61,9 +61,18 @@ defmodule Ferry.Profiles do
     |> Repo.get(id)
   end
 
+  @doc """
+  Return a single group, given its slug
+  """
+  @spec get_group_by_slug(String.t()) :: {:ok, Group.t()} :: :not_found
   def get_group_by_slug(slug) do
-    query = group_query(preload: [:addresses])
-    Repo.get_by(query, slug: slug)
+    case group_query(preload: [:addresses]) |> Repo.get_by(slug: slug) do
+      nil ->
+        :not_found
+
+      group ->
+        {:ok, group}
+    end
   end
 
   @doc """
@@ -161,6 +170,35 @@ defmodule Ferry.Profiles do
       end
 
     query
+  end
+
+  @spec setup_distributeaid() :: :ok
+  @doc """
+  Sets up the Distribute aid group. This is a well known
+  group that we need in order to check
+  for privileged access in account management.
+  """
+  def setup_distributeaid() do
+    with {:ok, group} <-
+           create_group(%{
+             name: "DistributeAid",
+             slug: "distributeaid",
+             type: "M4D_CHAPTER",
+             leader: "",
+             description: "DistributeAid",
+             donation_link: "https://request.example.com",
+             slack_channel_name: "",
+             request_form: "https://request.example.com",
+             request_form_results: "https://request.example.com/results",
+             volunteer_form: "https://volunteer.example.com",
+             volunteer_form_results: "https://volunteer.example.com/results",
+             donation_form: "https://donation.example.com",
+             donation_form_results: "https://donation.example.com/results"
+           }) do
+      Ecto.Adapters.SQL.query(Repo, "UPDATE groups SET id = 0 WHERE id = $1", [group.id])
+    end
+
+    :ok
   end
 
   # Project

--- a/lib/ferry/startup_tasks.ex
+++ b/lib/ferry/startup_tasks.ex
@@ -4,6 +4,7 @@ defmodule Ferry.StartupTasks do
     path = Application.app_dir(:ferry, "priv/repo/migrations")
     # Run the Ecto.Migrator
     Ecto.Migrator.run(Ferry.Repo, path, :up, all: true)
+    Ferry.Profiles.setup_distributeaid()
     Ferry.Token.setup()
   end
 end

--- a/lib/ferry_api/group_schema.ex
+++ b/lib/ferry_api/group_schema.ex
@@ -96,6 +96,7 @@ defmodule FerryApi.Schema.Group do
   end
 
   def get_group(_parent, %{id: id}, _resolution) do
+    # TODO: return either :not_found or {:ok, group}
     case Profiles.get_group(id) do
       nil -> {:error, message: "Group not found.", id: id}
       group -> {:ok, group}
@@ -103,9 +104,8 @@ defmodule FerryApi.Schema.Group do
   end
 
   def get_group_by_slug(_parent, %{slug: slug}, _resolution) do
-    case Profiles.get_group_by_slug(slug) do
-      nil -> {:error, message: "Group not found.", slug: slug}
-      group -> {:ok, group}
+    with :not_found <- Profiles.get_group_by_slug(slug) do
+      {:error, message: "Group not found.", slug: slug}
     end
   end
 

--- a/lib/ferry_api/middleware/require_da_admin.ex
+++ b/lib/ferry_api/middleware/require_da_admin.ex
@@ -1,0 +1,27 @@
+defmodule FerryApi.Middleware.RequireDaAdmin do
+  @doc """
+  Simple GraphQL middleware that checks whether or
+  not the user performing an action is a DistributeAid
+  admin.
+
+  We rely on the fact that we know the DistributeAid
+  group exists and has id "0".
+  """
+  @behaviour Absinthe.Middleware
+
+  def call(%{context: %{user: user}} = resolution, _opts) do
+    case Ferry.Accounts.has_role?(user, "0", "admin") do
+      true ->
+        resolution
+
+      false ->
+        resolution
+        |> Absinthe.Resolution.put_result({:error, "unauthorized"})
+    end
+  end
+
+  def call(resolution, _opts) do
+    resolution
+    |> Absinthe.Resolution.put_result({:error, "unauthorized"})
+  end
+end

--- a/lib/ferry_api/middleware/require_da_or_group_admin.ex
+++ b/lib/ferry_api/middleware/require_da_or_group_admin.ex
@@ -1,0 +1,16 @@
+defmodule FerryApi.Middleware.RequireDaOrGroupAdmin do
+  @doc """
+  Composite GraphQL middleware that checks for a
+  DistributeAid admin, or a group admin.
+
+  Relies on existing middleware.
+  """
+  @behaviour Absinthe.Middleware
+  alias FerryApi.Middleware.{RequireDaAdmin, RequireGroupAdmin}
+
+  def call(resolution, opts) do
+    with %{errors: [_ | _]} <- RequireDaAdmin.call(resolution, opts) do
+      RequireGroupAdmin.call(resolution, opts)
+    end
+  end
+end

--- a/lib/ferry_api/middleware/require_group_admin.ex
+++ b/lib/ferry_api/middleware/require_group_admin.ex
@@ -3,8 +3,8 @@ defmodule FerryApi.Middleware.RequireGroupAdmin do
   Simple GraphQL middleware that checks whether the current
   user is an admin in the group found in the arguments.
 
-  This middleware may be reused in multiple resolvers by
-  adding extra function clauses in order to decide where
+  This middleware may be reused in multiple resolvers if necessary
+  by adding extra function clauses, in order to decide where
   in the current scope the relevant group should be taken from.
   """
   @behaviour Absinthe.Middleware

--- a/lib/ferry_api/middleware/require_group_admin.ex
+++ b/lib/ferry_api/middleware/require_group_admin.ex
@@ -1,0 +1,22 @@
+defmodule FerryApi.Middleware.RequireGroupAdmin do
+  @doc """
+  Simple GraphQL middleware that checks whether the current
+  user is an admin in the group found in the arguments.
+
+  This middleware may be reused in multiple resolvers by
+  adding extra function clauses in order to decide where
+  in the current scope the relevant group should be taken from.
+  """
+  @behaviour Absinthe.Middleware
+
+  def call(%{arguments: %{group: group}, context: %{user: user}} = resolution, _opts) do
+    case Ferry.Accounts.has_role?(user, group, "admin") do
+      true ->
+        resolution
+
+      false ->
+        resolution
+        |> Absinthe.Resolution.put_result({:error, "unauthorized"})
+    end
+  end
+end

--- a/lib/ferry_api/middleware/require_user.ex
+++ b/lib/ferry_api/middleware/require_user.ex
@@ -1,9 +1,19 @@
 defmodule FerryApi.Middleware.RequireUser do
+  @doc """
+  Simple GraphQL middleware that checks
+  for a valid user in the current scope.
+  """
   @behaviour Absinthe.Middleware
+  alias Ferry.Accounts.User
 
-  def call(%{context: %{user: _user}} = resolution, _opts) do
+  def call(%{context: %{user: %User{}}} = resolution, _opts) do
     resolution
   end
 
-  def call(resolution, _opts), do: resolution
+  def call(resolution, _opts) do
+    resolution
+    # TODO uncomment this once all tests have proper
+    # user fixtures
+    # |> Absinthe.Resolution.put_result({:error, "unauthorized"})
+  end
 end

--- a/test/ferry/profiles/profiles_test.exs
+++ b/test/ferry/profiles/profiles_test.exs
@@ -11,17 +11,17 @@ defmodule Ferry.ProfilesTest do
     alias Ferry.Profiles.Group
 
     test "list_groups/0 returns all groups" do
-      # no groups
-      assert Profiles.list_groups() == [],
-             "returns an empty list if no groups have been created"
+      # no groups a part from the default distribute aid
+      # group
+      [%{name: "DistributeAid"}] = Profiles.list_groups()
 
-      # 1 group
-      group1 = insert(:group)
-      assert Profiles.list_groups() == [group1]
+      # 1 extra group
+      insert(:group, %{name: "group1"})
+      [_, %{name: "group1"}] = Profiles.list_groups()
 
       # multiple groups
-      group2 = insert(:group, %{name: "A Second Group"})
-      assert Profiles.list_groups() == [group1, group2]
+      insert(:group, %{name: "group2"})
+      [_, %{name: "group1"}, %{name: "group2"}] = Profiles.list_groups()
     end
 
     test "get_group!/1 returns the group with given id" do

--- a/test/ferry_api/group_address_api_test.exs
+++ b/test/ferry_api/group_address_api_test.exs
@@ -1,6 +1,7 @@
 defmodule Ferry.GroupAddressApiTest do
   use FerryWeb.ConnCase, async: true
-  import Ferry.ApiClient.{Group, Address}
+  import Ferry.ApiClient.Group
+  import Ferry.ApiClient.Address
 
   test "fetch a group and its addresses", %{conn: conn} do
     insert(:user)
@@ -76,6 +77,9 @@ defmodule Ferry.GroupAddressApiTest do
     %{
       "data" => %{
         "groups" => [
+          %{
+            "name" => "DistributeAid"
+          },
           %{
             "name" => "first group",
             "addresses" => [

--- a/test/ferry_api/group_api_test.exs
+++ b/test/ferry_api/group_api_test.exs
@@ -11,19 +11,19 @@ defmodule Ferry.GroupApiTest do
 
   test "count groups - none", %{conn: conn} do
     %{"data" => %{"countGroups" => count}} = count_groups(conn)
-    assert count == 0
+    assert count == 1
   end
 
   test "count groups - many", %{conn: conn} do
     insert_list(3, :group)
     %{"data" => %{"countGroups" => count}} = count_groups(conn)
-    assert count == 3
+    assert count == 4
   end
 
   # Query - Get All Groups
   # ------------------------------------------------------------
   test "get all groups - none", %{conn: conn} do
-    assert get_groups(conn) == %{"data" => %{"groups" => []}}
+    %{"data" => %{"groups" => [%{"name" => "DistributeAid"}]}} = get_groups(conn)
   end
 
   test "get all groups - one", %{conn: conn} do
@@ -50,7 +50,7 @@ defmodule Ferry.GroupApiTest do
 
     %{
       "data" => %{
-        "groups" => ^expected_groups
+        "groups" => [_ | ^expected_groups]
       }
     } = get_groups(conn)
   end
@@ -79,7 +79,7 @@ defmodule Ferry.GroupApiTest do
 
     %{
       "data" => %{
-        "groups" => ^expected_groups
+        "groups" => [_ | ^expected_groups]
       }
     } = get_groups(conn)
   end

--- a/test/ferry_api/group_project_api_test.exs
+++ b/test/ferry_api/group_project_api_test.exs
@@ -79,6 +79,8 @@ defmodule Ferry.GroupProjectApiTest do
     %{
       "data" => %{
         "groups" => [
+          # built-in group
+          %{"name" => "DistributeAid"},
           %{
             "name" => "first group",
             "projects" => [

--- a/test/ferry_api/user_group_api_test.exs
+++ b/test/ferry_api/user_group_api_test.exs
@@ -151,46 +151,49 @@ defmodule Ferry.UserGroupApiTest do
       } = get_user(conn, member.id)
     end
 
-    #    test "cannot set the role of existing users in other groups", %{conn: conn} = context do
-    #      # Sets up some aid group and its admin user
-    #      {:ok, %{user: admin}} =
-    #        Ferry.Fixture.GroupUserRole.setup(context, %{
-    #          group: "group",
-    #          user: "admin@group",
-    #          role: "admin"
-    #        })
-    #
-    #      # Set up a different group group and its admin user
-    #      {:ok, %{group: group2}} =
-    #        Ferry.Fixture.GroupUserRole.setup(context, %{
-    #          group: "group2",
-    #          user: "admin@group2",
-    #          role: "admin"
-    #        })
-    #
-    #      # Add a new user to the system
-    #      {:ok, member} = Ferry.Accounts.create_user(%{email: "member@group2"})
-    #
-    #      # Authenticate as the admin in the first group
-    #      conn = auth(conn, admin)
-    #
-    #      # Attempt to change the role of user in the second group
-    #      %{
-    #        "data" => %{
-    #          "setUserRole" => %{
-    #            "successful" => false,
-    #          }
-    #        }
-    #      } =
-    #        set_user_role(conn, %{
-    #          user: member.id,
-    #          group: group2.id,
-    #          role: "admin"
-    #        })
-    #
-    #      # Verify the role hasnt changed
-    #      {:ok, member} = Ferry.Accounts.get_user(member.id)
-    #      assert [%{role: "member"}] = member.groups
-    #    end
+    test "cannot set the role of existing users in other groups", %{conn: conn} = context do
+      # Sets up some aid group and its admin user
+      {:ok, %{user: admin}} =
+        Ferry.Fixture.GroupUserRole.setup(context, %{
+          group: "group",
+          user: "admin@group",
+          role: "admin"
+        })
+
+      # Set up a different group group and its admin user
+      {:ok, %{group: group2}} =
+        Ferry.Fixture.GroupUserRole.setup(context, %{
+          group: "group2",
+          user: "admin@group2",
+          role: "admin"
+        })
+
+      # Add a new user to the system
+      {:ok, member} = Ferry.Accounts.create_user(%{email: "member@group2"})
+
+      # Authenticate as the admin in the first group
+      conn = auth(conn, admin)
+
+      # Attempt to change the role of user in the second group
+      %{
+        "data" => %{
+          "setUserRole" => %{
+            "successful" => false,
+            "messages" => [
+              %{"message" => "unauthorized"}
+            ]
+          }
+        }
+      } =
+        set_user_role(conn, %{
+          user: member.id,
+          group: group2.id,
+          role: "admin"
+        })
+
+      # Verify the role hasnt changed
+      {:ok, member} = Ferry.Accounts.get_user(member.id)
+      assert [] == member.groups
+    end
   end
 end

--- a/test/support/api_client/user.ex
+++ b/test/support/api_client/user.ex
@@ -95,7 +95,7 @@ defmodule Ferry.ApiClient.User do
   Run a GraphQL mutation that deletes a role
   for a given user in a group
   """
-  @spec set_user_role(Plug.Conn.t(), map()) :: map()
+  @spec delete_user_role(Plug.Conn.t(), map()) :: map()
   def delete_user_role(conn, attrs) do
     graphql(conn, """
       mutation {

--- a/test/support/fixture/distribute_aid.ex
+++ b/test/support/fixture/distribute_aid.ex
@@ -5,7 +5,7 @@ defmodule Ferry.Fixture.DistributeAid do
 
   def setup(context) do
     {:ok, %{group: group, user: user}} =
-      Ferry.Fixture.GroupUserRole.setup(context, %{
+      Ferry.Fixture.UserRole.setup(context, %{
         group: "distributeaid",
         user: "admin@distributeaid.org",
         role: "admin"

--- a/test/support/fixture/user_role.ex
+++ b/test/support/fixture/user_role.ex
@@ -1,0 +1,23 @@
+defmodule Ferry.Fixture.UserRole do
+  @doc """
+  A fixture that creates a user, and a membership
+  for that user in that group, with the given role.
+
+  The group lookup is by slug.
+  """
+  alias Ferry.Profiles
+  alias Ferry.Accounts
+
+  def setup(context, %{group: group, user: email, role: role}) do
+    # find the group by its slug
+    {:ok, group} = Profiles.get_group_by_slug(group)
+
+    # create the user
+    {:ok, user} = Accounts.create_user(%{email: email})
+
+    # add the user to the group, using the given role
+    {:ok, user} = Accounts.set_user_role(user, group, role)
+
+    {:ok, Map.merge(context, %{group: group, user: user})}
+  end
+end


### PR DESCRIPTION
This PR implements some basic absinthe middleware modules so that we can easily protect GraphQL resolvers in a declarative way. 

These middleware are designed for easy use cases only. 

For more complex checks, we can implement more focused authorisation checks in the resolvers themselves if that's needed.

List of middleware implemented in this PR:

* RequireDaAdmin
* RequireGroupAdmin
* RequireDaAdminOrGroupAdmin

Also this PR is now hardcoding `DistributeAid` as the default group, with well known id `0`. This allows use to rename the group if necessary, but the toolbox will still know it is the default group. And users in that group with the `admin` role will be considered DistributeAid admins and they will have privileged access to user account management in this group and **any** other group in the system.

However, admin users in groups other than `DistributeAid` will have user account management permissions in those specific groups only.

Fixes #100 
